### PR TITLE
Convert code to class-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Not in any specific order :
 - Add flag for 'default' repo directory (or another specific directory - if it does not already exist it will be created and added to the standard list) which will be used for new additions.
 - Option to save log file for each run.
 - Add option to only display a (text) tree of the discovered git repositories, not updating them; Similar option to just dump a list of the remote git locations.
+- Add ability to export a text dump of each repo location and then re-import this on a different machine or after reinstall
 - Document configuration file format and options.
 - Add testing!
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ This is the conversion to a Gem of one of my standalone Ruby scripts. Still very
 
 #### Pre-requirements
 
-It goes without saying that at the very least a working copy of [Git][git] needs to be installed on your machine. Also, the script has only been tested under Linux, not windows.
+It goes without saying that at the very least a working copy of both [`Git`][git] and [`Ruby`][ruby] need to be installed on your machine. Also, the script has only been tested under Linux, not windows.
 
 [git]: http://git-scm.com
+[ruby]: http://www.ruby-lang.org
 
 #### Quick start
 Create a [YAML](http://yaml.org/)-formatted configuration file `.updatereporc` **in your home directory** that contains at least a 'location' tag pointing to the directory containing the git repositories you wish to have updated :
@@ -46,6 +47,8 @@ To be added.
 Not in any specific order :
 
 - Improve error-checking and recovery while parsing the configuration file (convert to using my '[Confoog][confoog]' gem for example)
+  * Ignore and report invalid or missing directories
+  * Expand eg '~/' to full valid path.
 - Either add an option 'variants' or similar to allow non-standard git pull commands (eg Ubuntu kernel), or update the 'exceptions' option to do same.
 - Error checking and reporting for the git processes - retry for connection issues etc (config setting).
 - Add extra (optional) stats / info at end-of-job :

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'inch/rake'
-require 'wwtd/tasks'
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -28,5 +27,5 @@ else
   end
 end
 
-# task default: [:rubocop, :inch, :reek, :spec, :wwtd, :build]
-task default: [:spec, :build] # leave the others off until we are more advanced.
+# task default: [:rubocop, :inch, :reek, :spec, :build]
+task default: [:rubocop, :spec, :build] # leave the others off for now.

--- a/Rakefile
+++ b/Rakefile
@@ -28,4 +28,4 @@ else
 end
 
 # task default: [:rubocop, :inch, :reek, :spec, :build]
-task default: [:rubocop, :spec, :build] # leave the others off for now.
+task default: [:rubocop, :inch, :spec, :build] # leave the others off for now.

--- a/exe/update_repo
+++ b/exe/update_repo
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require "update_repo"
+require 'update_repo'
 
 walk_repo = UpdateRepo::WalkRepo.new
 # start the process...
@@ -8,13 +8,11 @@ configs, location = walk_repo.check_config
 walk_repo.show_header(configs, location)
 
 # save the current time
-start_time = Time.now
+# walk_repo.start_time = Time.now
+
 configs['location'].each do |loc|
   walk_repo.recurse_dir(loc, configs['exceptions'])
 end
 
-# get operation duration...
-duration = Time.now - start_time
-
-# print out a brief footer. This will be expanded later.
-puts "\nUpdates completed - #{walk_repo.counter} repositories processed in #{Time.at(duration).utc.strftime("%H:%M:%S")}\n".underline
+# print out an informative footer...
+walk_repo.footer

--- a/exe/update_repo
+++ b/exe/update_repo
@@ -2,17 +2,7 @@
 
 require 'update_repo'
 
+# create a new instance of the class...
 walk_repo = UpdateRepo::WalkRepo.new
-# start the process...
-configs, location = walk_repo.check_config
-walk_repo.show_header(configs, location)
-
-# save the current time
-# walk_repo.start_time = Time.now
-
-configs['location'].each do |loc|
-  walk_repo.recurse_dir(loc, configs['exceptions'])
-end
-
-# print out an informative footer...
-walk_repo.footer
+# then start the process...
+walk_repo.start

--- a/exe/update_repo
+++ b/exe/update_repo
@@ -1,20 +1,20 @@
 #!/usr/bin/env ruby
 
-require 'update_repo'
-include UpdateRepo
+require "update_repo"
 
+walk_repo = UpdateRepo::WalkRepo.new
 # start the process...
-configs, location = check_config
-
-show_header(configs, location)
+configs, location = walk_repo.check_config
+walk_repo.show_header(configs, location)
 
 # save the current time
 start_time = Time.now
 configs['location'].each do |loc|
-  recurse_dir(loc, configs['exceptions'])
+  walk_repo.recurse_dir(loc, configs['exceptions'])
 end
 
-# get duration since we saved the time
+# get operation duration...
 duration = Time.now - start_time
 
-puts "\nUpdates completed - #{$counter} repositories processed in #{Time.at(duration).utc.strftime('%H:%M:%S')}\n".underline
+# print out a brief footer. This will be expanded later.
+puts "\nUpdates completed - #{walk_repo.counter} repositories processed in #{Time.at(duration).utc.strftime("%H:%M:%S")}\n".underline

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -84,7 +84,7 @@ module UpdateRepo
     private
 
     def list_locations(configs)
-      puts "\nRepo location(s):".underline
+      print "\nRepo location(s):\n".underline
       configs['location'].each do |loc|
         print '-> ', loc.cyan, "\n"
       end

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -1,73 +1,82 @@
 require 'update_repo/version'
 require 'yaml'
 require 'colorize'
+require 'update_repo/version'
 
 module UpdateRepo
 
   CONFIG_FILE = '.updatereporc'
-  $counter = 0
 
-  def recurse_dir(dirname, exceptions)
-    Dir.foreach(dirname) do |dir|
-      dirpath = dirname + '/' + dir
-      if File.directory?(dirpath) && dir != '.' && dir != '..'
-        gitpath = dirpath + '/.git'
-        if File.exist?(gitpath) && File.directory?(gitpath)
-          if !exceptions.include?(dir.chomp)
-            update_repo(dirpath)
-            $counter += 1
-          else
-            Dir.chdir(gitpath) do
-              repo_url = `git config remote.origin.url`.chomp
-              print "* Skipping #{dirpath}".yellow, " (#{repo_url})\n"
+  class WalkRepo
+    attr_reader :counter
+  # $counter = 0
+
+    def initialize
+      @counter = 0
+    end
+
+    def recurse_dir(dirname, exceptions)
+      Dir.foreach(dirname) do |dir|
+        dirpath = dirname + '/' + dir
+        if File.directory?(dirpath) && dir != '.' && dir != '..'
+          gitpath = dirpath + '/.git'
+          if File.exist?(gitpath) && File.directory?(gitpath)
+            if !exceptions.include?(dir.chomp)
+              update_repo(dirpath)
+              @counter += 1
+            else
+              Dir.chdir(gitpath) do
+                repo_url = `git config remote.origin.url`.chomp
+                print "* Skipping #{dirpath}".yellow, " (#{repo_url})\n"
+              end
             end
+          else
+            recurse_dir(dirpath, exceptions)
           end
-        else
-          recurse_dir(dirpath, exceptions)
         end
       end
     end
-  end
 
-  def show_header(configs, location)
-    # print an informative header before starting
-    print "\nGit Repo update utility (v.0.1.0)".underline, " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
-    puts "Using Configuration from #{location}"
-    puts "\nRepo location(s):".underline
-    configs['location'].each do |loc|
-      print '-> ', loc.cyan, "\n"
+    def show_header(configs, location)
+      # print an informative header before starting
+      print "\nGit Repo update utility (v", VERSION,")", " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
+      puts "Using Configuration from #{location}"
+      puts "\nRepo location(s):".underline
+      configs['location'].each do |loc|
+        print '-> ', loc.cyan, "\n"
+      end
+      if configs['exceptions']
+        print "\nExclusions:".underline, ' ', configs['exceptions'].join(', ').yellow, "\n"
+      end
+      puts # blank line before processing starts
     end
-    if configs['exceptions']
-      print "\nExclusions:".underline, ' ', configs['exceptions'].join(', ').yellow, "\n"
-    end
-    puts # blank line before processing starts
-  end
 
-  def update_repo(dirname)
-    Dir.chdir(dirname) do
-      repo_url = `git config remote.origin.url`.chomp
-      print '* ', 'Checking ', dirname.green, " (#{repo_url})\n"
-      print '  -> '
-      system 'git pull'
+    def update_repo(dirname)
+      Dir.chdir(dirname) do
+        repo_url = `git config remote.origin.url`.chomp
+        print '* ', 'Checking ', dirname.green, " (#{repo_url})\n"
+        print '  -> '
+        system 'git pull'
+      end
     end
-  end
 
-  def check_config
-    # locate the configuration file.
-    # first we check in this script location and if present then we ignore any
-    # further files.
-    dev_config = File.join '.', CONFIG_FILE
-    user_config = File.join Gem.user_home, CONFIG_FILE
+    def check_config
+      # locate the configuration file.
+      # first we check in this script location and if present then we ignore any
+      # further files.
+      dev_config = File.join '.', CONFIG_FILE
+      user_config = File.join Gem.user_home, CONFIG_FILE
 
-    if File.exist? dev_config
-      # configuration exists in script directory so we ignore any others.
-      return YAML.load_file(dev_config), File.expand_path(dev_config)
-    elsif File.exist? user_config
-      # configuration exists in user home directory so we use that.
-      return YAML.load_file(user_config), File.expand_path(user_config)
+      if File.exist? dev_config
+        # configuration exists in script directory so we ignore any others.
+        return YAML.load_file(dev_config), File.expand_path(dev_config)
+      elsif File.exist? user_config
+        # configuration exists in user home directory so we use that.
+        return YAML.load_file(user_config), File.expand_path(user_config)
+      end
+      # otherwise return error
+      puts "Error : Cannot find configuration file '#{user_config}', aborting".red
+      exit 1
     end
-    # otherwise return error
-    puts "Error : Cannot find configuration file '#{user_config}', aborting".red
-    exit 1
   end
 end

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -43,15 +43,15 @@ module UpdateRepo
       # print an informative header before starting
       print "\nGit Repo update utility (v", VERSION, ')',
             " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
-      puts "Using Configuration from #{location}"
-      list_locations(configs, location)
+      print "Using Configuration from #{location}\n"
+      list_locations(configs)
       if configs['exceptions']
         print "\nExclusions:".underline, ' ',
               configs['exceptions'].join(', ').yellow, "\n"
       end
       # save the start time for later display in the footer...
       @start_time = Time.now
-      puts # blank line before processing starts
+      print "\n" # blank line before processing starts
     end
 
     def check_config
@@ -69,7 +69,8 @@ module UpdateRepo
         return YAML.load_file(user_config), File.expand_path(user_config)
       end
       # otherwise return error
-      puts "Error : Cannot find configuration file '#{user_config}', aborting".red
+      print 'Error : Cannot find configuration file'.red, user_config.red,
+            'aborting'.red
       exit 1
     end
 
@@ -82,7 +83,7 @@ module UpdateRepo
 
     private
 
-    def list_locations(configs, location)
+    def list_locations(configs)
       puts "\nRepo location(s):".underline
       configs['location'].each do |loc|
         print '-> ', loc.cyan, "\n"

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -3,16 +3,21 @@ require 'yaml'
 require 'colorize'
 require 'update_repo/version'
 
+# Overall module with classes performing the functionality
+# Contains Class UpdateRepo::WalkRepo
 module UpdateRepo
+  CONFIG_FILE = '.updatereporc'.freeze
 
-  CONFIG_FILE = '.updatereporc'
-
+  # An encapsulated class to walk the repo directories and update all Git
+  # repositories found therein.
   class WalkRepo
     attr_reader :counter
-  # $counter = 0
+    attr_writer :start_time
+    # $counter = 0
 
     def initialize
       @counter = 0
+      @start_time = 0
     end
 
     def recurse_dir(dirname, exceptions)
@@ -25,10 +30,7 @@ module UpdateRepo
               update_repo(dirpath)
               @counter += 1
             else
-              Dir.chdir(gitpath) do
-                repo_url = `git config remote.origin.url`.chomp
-                print "* Skipping #{dirpath}".yellow, " (#{repo_url})\n"
-              end
+              skip_dir(dirpath)
             end
           else
             recurse_dir(dirpath, exceptions)
@@ -39,25 +41,17 @@ module UpdateRepo
 
     def show_header(configs, location)
       # print an informative header before starting
-      print "\nGit Repo update utility (v", VERSION,")", " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
+      print "\nGit Repo update utility (v", VERSION, ')',
+            " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
       puts "Using Configuration from #{location}"
-      puts "\nRepo location(s):".underline
-      configs['location'].each do |loc|
-        print '-> ', loc.cyan, "\n"
-      end
+      list_locations(configs, location)
       if configs['exceptions']
-        print "\nExclusions:".underline, ' ', configs['exceptions'].join(', ').yellow, "\n"
+        print "\nExclusions:".underline, ' ',
+              configs['exceptions'].join(', ').yellow, "\n"
       end
+      # save the start time for later display in the footer...
+      @start_time = Time.now
       puts # blank line before processing starts
-    end
-
-    def update_repo(dirname)
-      Dir.chdir(dirname) do
-        repo_url = `git config remote.origin.url`.chomp
-        print '* ', 'Checking ', dirname.green, " (#{repo_url})\n"
-        print '  -> '
-        system 'git pull'
-      end
     end
 
     def check_config
@@ -77,6 +71,37 @@ module UpdateRepo
       # otherwise return error
       puts "Error : Cannot find configuration file '#{user_config}', aborting".red
       exit 1
+    end
+
+    def footer
+      # print out a brief footer. This will be expanded later.
+      duration = Time.now - @start_time
+      print "\nUpdates completed - #{@counter} repositories processed in ",
+            "#{Time.at(duration).utc.strftime('%H:%M:%S')}\n\n".cyan
+    end
+
+    private
+
+    def list_locations(configs, location)
+      puts "\nRepo location(s):".underline
+      configs['location'].each do |loc|
+        print '-> ', loc.cyan, "\n"
+      end
+    end
+
+    def skip_dir(dirpath)
+      Dir.chdir(dirpath) do
+        repo_url = `git config remote.origin.url`.chomp
+        print "* Skipping #{dirpath}".yellow, " (#{repo_url})\n"
+      end
+    end
+
+    def update_repo(dirname)
+      Dir.chdir(dirname) do
+        repo_url = `git config remote.origin.url`.chomp
+        print '* ', 'Checking ', dirname.green, " (#{repo_url})\n", '  -> '
+        system 'git pull'
+      end
     end
   end
 end

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -6,19 +6,27 @@ require 'update_repo/version'
 # Overall module with classes performing the functionality
 # Contains Class UpdateRepo::WalkRepo
 module UpdateRepo
+  # This constant holds the name to the config file, located in ~/
   CONFIG_FILE = '.updatereporc'.freeze
 
   # An encapsulated class to walk the repo directories and update all Git
   # repositories found therein.
   class WalkRepo
+    # Read-only attribute holding the total number of traversed repositories
+    # @attr_reader :counter [fixnum] total number of traversed repositories
     attr_reader :counter
 
+    # Class constructor. No parameters required.
+    # @return [void]
     def initialize
       @counter = 0
       @start_time = 0
     end
 
-    # This function will perform the required actions
+    # This function will perform the required actions to traverse the Repo.
+    # @example
+    #   walk_repo = UpdateRepo::WalkRepo.new
+    #   walk_repo.start
     def start
       configs, location = check_config
       show_header(configs, location)
@@ -29,6 +37,12 @@ module UpdateRepo
       footer
     end
 
+    private
+
+    # take each directory contained in the Repo directory, and if it is detected
+    # as a Git repository then update it.
+    # @param dirname [string] Contains the directory to search for Git repos.
+    # @param exceptions [array] Each repo matching one of these will be ignored.
     def recurse_dir(dirname, exceptions)
       Dir.foreach(dirname) do |dir|
         dirpath = dirname + '/' + dir
@@ -42,21 +56,10 @@ module UpdateRepo
       end
     end
 
-    def show_header(configs, location)
-      # print an informative header before starting
-      print "\nGit Repo update utility (v", VERSION, ')',
-            " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
-      print "Using Configuration from #{location}\n"
-      list_locations(configs)
-      if configs['exceptions']
-        print "\nExclusions:".underline, ' ',
-              configs['exceptions'].join(', ').yellow, "\n"
-      end
-      # save the start time for later display in the footer...
-      @start_time = Time.now
-      print "\n" # blank line before processing starts
-    end
-
+    # locate the configuration file and return this data.
+    # Note that this will be re-written later to use my 'confoog' gem.
+    # @return [hash] Hash containing all the configuration parameters.
+    # @return [string] Location of the configuration file.
     def check_config
       # locate the configuration file.
       # first we check in this script location and if present then we ignore any
@@ -77,14 +80,34 @@ module UpdateRepo
       exit 1
     end
 
+    # Display a simple header to the console
+    # @param configs [hash] Configuration hash, used here to list exceptions.
+    # @param location [string] location of config file.
+    # @example
+    #   show_header
+    # @return []
+    def show_header(configs, location)
+      # print an informative header before starting
+      print "\nGit Repo update utility (v", VERSION, ')',
+            " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
+      print "Using Configuration from #{location}\n"
+      list_locations(configs)
+      if configs['exceptions']
+        print "\nExclusions:".underline, ' ',
+              configs['exceptions'].join(', ').yellow, "\n"
+      end
+      # save the start time for later display in the footer...
+      @start_time = Time.now
+      print "\n" # blank line before processing starts
+    end
+
+    # print out a brief footer. This will be expanded later.
+    # @return [void]
     def footer
-      # print out a brief footer. This will be expanded later.
       duration = Time.now - @start_time
       print "\nUpdates completed - #{@counter} repositories processed in ",
             "#{Time.at(duration).utc.strftime('%H:%M:%S')}\n\n".cyan
     end
-
-    private
 
     def list_locations(configs)
       print "\nRepo location(s):\n".underline

--- a/lib/update_repo/version.rb
+++ b/lib/update_repo/version.rb
@@ -1,3 +1,4 @@
 module UpdateRepo
+  # constant, current version of this Gem
   VERSION = '0.2.0'.freeze
 end

--- a/lib/update_repo/version.rb
+++ b/lib/update_repo/version.rb
@@ -1,3 +1,3 @@
 module UpdateRepo
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
Code structure re-written to be encapsulated by a class 'WalkRepo'

In the process : 
  * The code was heavily refactored to pass `'Rubocop'` with no errors or advisories, so the `:rubocop` task was added to the default `rake` task.
  * The executable was simplified, with all steps being encapsulated into the `WalkRepo.start` method.
  * README.md was clarified and the `to-do` added to.
  * Extensive inline documentation was added, so `inch --pedantic` now passes. `Inch` added to default `rake` task.
  * All class methods except `initialize` and `start` were made private.