### PR TITLE
Refactor the 'recurse_dir' function.

### DIFF
--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -87,7 +87,7 @@ EOS
     # @param dir [string] Directory to be checked
     # @return [boolean] True if this is NOT an exception, False otherwise
     def notexception?(dir)
-      !@config['exceptions'].include?(dir.chomp('/'))
+      !@config['exceptions'].include?(File.basename(dir))
     end
 
     # Display a simple header to the console

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -129,7 +129,7 @@ EOS
     def skip_repo(dirpath)
       Dir.chdir(dirpath.chomp!('/')) do
         repo_url = `git config remote.origin.url`.chomp
-        print "* Skipping #{dirpath}".yellow, " (#{repo_url})\n"
+        print '* Skipping ', Dir.pwd.yellow, " (#{repo_url})\n"
         @skip_count += 1
       end
     end
@@ -137,7 +137,7 @@ EOS
     def update_repo(dirname)
       Dir.chdir(dirname.chomp!('/')) do
         repo_url = `git config remote.origin.url`.chomp
-        print '* ', 'Checking ', dirname.green, " (#{repo_url})\n", '  -> '
+        print '* Checking ', Dir.pwd.green, " (#{repo_url})\n", '  -> '
         system 'git pull'
         @counter += 1
       end


### PR DESCRIPTION
Function is much simpler and now does not recurse since that is taken
care of by the `Dir['**/']` command. Basically each call of this will
return all Git directories below the specified directory.

Removed and refectored some other methods to aid this.

Signed-off-by: Grant Ramsay <seapagan@gmail.com>