### PR TITLE
Rename default config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It goes without saying that at the very least a working copy of both [`Git`][git
 [ruby]: http://www.ruby-lang.org
 
 #### Quick start
-Create a [YAML](http://yaml.org/)-formatted configuration file `.updatereporc` **in your home directory** that contains at least a 'location' tag pointing to the directory containing the git repositories you wish to have updated :
+Create a [YAML](http://yaml.org/)-formatted configuration file `.updaterepo` **in your home directory** that contains at least a 'location' tag pointing to the directory containing the git repositories you wish to have updated :
 ```yaml
 ---
 location:
@@ -29,7 +29,7 @@ location:
 ```
 This is the most basic example of a configuration file and there are other options that can be added to fine-tune the operation - see the description of configuration options below.
 
-This file should be located in the users home directory (`~/.updatereporc`).
+This file should be located in the users home directory (`~/.updaterepo`).
 
 Run the script :
 ```

--- a/exe/update_repo
+++ b/exe/update_repo
@@ -3,7 +3,7 @@ require 'update_repo'
 
 # Catch ctrl-c and abort gracefully without Ruby back trace...
 Signal.trap('INT') {
-  print "\r  -> ".red, "Aborting on user request.\n"
+  print "\r  -> ".red, "Aborting on user request.\n\n"
   exit
 }
 

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -59,7 +59,7 @@ Usage:
       update_repo [options]
 
 Options are not required. If none are specified then the program will read from
-the standard configuration file (~/.updaterepo) and automatically update the
+the standard configuration file (~/#{CONFIG_FILE}) and automatically update the
 specified Repositories.
 
 Options:

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -8,7 +8,7 @@ require 'trollop'
 # Contains Class UpdateRepo::WalkRepo
 module UpdateRepo
   # This constant holds the name to the config file, located in ~/
-  CONFIG_FILE = '.updatereporc'.freeze
+  CONFIG_FILE = '.updaterepo'.freeze
 
   # An encapsulated class to walk the repo directories and update all Git
   # repositories found therein.
@@ -24,7 +24,7 @@ module UpdateRepo
       @start_time = 0
       # @config - Class. Reads the configuration from a file in YAML format and
       # allows easy access to the configuration data
-      @config = Confoog::Settings.new(filename: '.updatereporc',
+      @config = Confoog::Settings.new(filename: CONFIG_FILE,
                                       prefix: 'update_repo',
                                       autoload: true,
                                       autosave: false)
@@ -59,7 +59,7 @@ Usage:
       update_repo [options]
 
 Options are not required. If none are specified then the program will read from
-the standard configuration file (~/.updatereporc) and automatically update the
+the standard configuration file (~/.updaterepo) and automatically update the
 specified Repositories.
 
 Options:

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -28,7 +28,7 @@ module UpdateRepo
                                       prefix: 'update_repo',
                                       autoload: true,
                                       autosave: false)
-      exit 1 unless @config.status[:errors] == Status::INFO_FILE_LOADED
+      config_error unless @config.status[:errors] == Status::INFO_FILE_LOADED
       # store the command line variables in a configuration variable
       @config['cmd'] = set_options
     end
@@ -47,6 +47,14 @@ module UpdateRepo
     end
 
     private
+
+    def config_error
+      if @config.status[:errors] == Status::ERR_CANT_LOAD
+        print 'Note that the the default configuration file was '.red,
+              "changed to ~/#{CONFIG_FILE} from v0.4.0 onwards\n\n".red
+      end
+      exit 1
+    end
 
     # rubocop:disable Metrics//MethodLength
     def set_options

--- a/lib/update_repo/version.rb
+++ b/lib/update_repo/version.rb
@@ -1,4 +1,4 @@
 module UpdateRepo
   # constant, current version of this Gem
-  VERSION = '0.3.3'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
Currently the default configuration file is located in the user's home directory and called `.updatereporc`.

The 'rc' prefix is probably a bit old-style and does not really fit the format of this file, so drop it. New default configuration is still in the user's home directory but called `.updaterepo`

Bumped version to `0.4.0` since this is a potentially breaking change, but not really enough to justify bumping the major version to 1. However, an additional error text was added to point out that the default configuration file has changed from this version on