### PR TITLE
More rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'inch/rake'
 RSpec::Core::RakeTask.new(:spec)
 
 RuboCop::RakeTask.new do |task|
-  task.options << 'lib'
+  task.options << 'lib' << 'exe'
 end
 
 Inch::Rake::Suggest.new do |suggest|

--- a/exe/update_repo
+++ b/exe/update_repo
@@ -2,10 +2,10 @@
 require 'update_repo'
 
 # Catch ctrl-c and abort gracefully without Ruby back trace...
-Signal.trap('INT') {
+Signal.trap('INT') do
   print "\r  -> ".red, "Aborting on user request.\n\n"
   exit
-}
+end
 
 # create a new instance of the class...
 walk_repo = UpdateRepo::WalkRepo.new


### PR DESCRIPTION
Add 'exe' dir to 'Rubocop' search path.

Would be useful to ensure that the gem execution file also conforms to the required 'Rubocop' specs.

Also fixed one non-conformity in exe/update_repo resulting from this.
