### PR TITLE
Handle git output

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ Not in any specific order :
 - Improve error-checking and recovery while parsing the configuration file
   * Ignore and report invalid or missing directories
 - Either add an option 'variants' or similar to allow non-standard git pull commands (eg Ubuntu kernel), or update the 'exceptions' option to do same.
-- Error checking and reporting for the git processes - retry for connection issues etc (config setting).
+- Error checking and reporting for the git processes `[IN PROGRESS]`
+  * Add more failure cases, not all git errors fail with "fatal:"
+- retry for connection issues etc (config setting).
 - Add extra (optional) stats / info at end-of-job :
-    * list of changed repos
-    * errors or connection problems
-    * _more..._
+  * list of changed repos
+  * errors or connection problems `[IN PROGRESS]`
+  * _more..._
 - Add command line options to override configuration, and even specify an alternate config file. Any options so specified will have precedence over settings specified in the configuration file.
 - Add command line options for verbose or quiet, with same options in config file.
 - Add ability to specify a new directory (containing Git repos) to search from the command line, and optionally save this to the standard configuration.

--- a/Rakefile
+++ b/Rakefile
@@ -1,21 +1,28 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
 require 'inch/rake'
 
 RSpec::Core::RakeTask.new(:spec)
 
-RuboCop::RakeTask.new do |task|
-  task.options << 'lib' << 'exe'
-  task.fail_on_error = false
+# rubocop is not compatible with Ruby < 2.0
+if RUBY_VERSION >= '2.0'
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new do |task|
+    task.options << 'lib' << 'exe'
+    task.fail_on_error = false
+  end
+else
+  task :rubocop do
+    # Empty task
+  end
 end
 
 Inch::Rake::Suggest.new do |suggest|
   suggest.args << '--pedantic'
 end
 
-# reek is not compatible with Ruby < 2.0]
-if RUBY_VERSION > '2.0'
+# reek is not compatible with Ruby < 2.0
+if RUBY_VERSION >= '2.0'
   require 'reek/rake/task'
   Reek::Rake::Task.new do |t|
     t.fail_on_error = false

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -49,7 +49,7 @@ module UpdateRepo
     #   walk_repo.start
     def start
       String.disable_colorization = true unless param_set('color')
-      show_header(@config['exceptions'])
+      show_header
       @config['location'].each do |loc|
         recurse_dir(loc)
       end
@@ -124,9 +124,9 @@ EOS
 
     # Display a simple header to the console
     # @example
-    #   show_header(exceptions)
+    #   show_header
     # @return [void]
-    def show_header(exceptions)
+    def show_header
       # print an informative header before starting
       # unless we are dumping the repo information
       return if dumping?
@@ -136,11 +136,8 @@ EOS
       print "Command line is : #{@config['cmd']}\n"
       # list out the locations that will be searched
       list_locations
-      # lisgt any exceptions that we have from the config file
-      if exceptions
-        print "\nExclusions:".underline, ' ',
-              exceptions.join(', ').yellow, "\n"
-      end
+      # list any exceptions that we have from the config file
+      list_exceptions
       # save the start time for later display in the footer...
       @start_time = Time.now
       print "\n" # blank line before processing starts
@@ -153,10 +150,18 @@ EOS
       return if dumping?
       duration = Time.now - @start_time
       print "\nUpdates completed : ", @counter.to_s.green,
-            ' repositories processed'
-      print ' / ', @skip_count.to_s.yellow, ' skipped' unless @skip_count == 0
-      print ' / ', @failed_count.to_s.red, ' failed'.red unless @fail_count == 0
+            ' repositories processed'.green
+      summary(@skip_count, 'yellow', 'skipped')
+      summary(@fail_count, 'red', 'failed')
       print ' in ', show_time(duration).cyan, "\n\n"
+    end
+
+    def list_exceptions
+      exceptions = @config['exceptions']
+      if exceptions
+        print "\nExclusions:".underline, ' ',
+              exceptions.join(', ').yellow, "\n"
+      end
     end
 
     def list_locations

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -1,4 +1,4 @@
-# Module 'Helers' containing assorted helper functions required elsewhere
+# Module 'Helpers' containing assorted helper functions required elsewhere
 module Helpers
   # will remove the FIRST 'how_many' root levels from a directory path 'dir'..
   # @param dir [string] Path to be truncated
@@ -6,7 +6,7 @@ module Helpers
   # @return [string] the properly truncated path
   def trunc_dir(dir, how_many)
     # make sure we don't lose any root slash if '--prune' is NOT specified
-    return dir if how_many == 0
+    return dir if how_many.zero?
     # convert to array then lose the first 'how_many' parts
     path_array = Pathname(dir).each_filename.to_a
     path_array = path_array.drop(how_many)
@@ -30,5 +30,11 @@ module Helpers
   def show_time(duration)
     time_taken = Time.at(duration).utc
     time_taken.strftime('%-H hours, %-M Minutes and %-S seconds.')
+  end
+
+  # print the specified summary metric, called from the footer.
+  def summary(which, color, event)
+    output = "#{which} #{event}"
+    print ' / ', output.send(color.to_sym) unless which.zero?
   end
 end

--- a/update_repo.gemspec
+++ b/update_repo.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'fakefs'
+  spec.add_development_dependency 'json', '= 1.8.3'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'inch'

--- a/update_repo.gemspec
+++ b/update_repo.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fakefs'
   spec.add_development_dependency 'json', '= 1.8.3'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'inch'
   spec.add_development_dependency 'simplecov', '~> 0.10'
   spec.add_development_dependency 'pullreview-coverage'
@@ -39,5 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'trollop'
 
   # Depends on Ruby version if we can use 'Reek'
-  spec.add_development_dependency 'reek', '~> 3.3' if RUBY_VERSION > '2.0'
+  spec.add_development_dependency 'reek', '~> 3.3' if RUBY_VERSION >= '2.0'
+  # Depends on Ruby version if we can use 'rubocop'
+  spec.add_development_dependency 'rubocop' if RUBY_VERSION >= '2.0'
 end


### PR DESCRIPTION
Basic functionality to check the 'git' output and lay the groundwork for more detailed error trapping and checking in the future.

Also refactor and tidy a little, fix some Rubocop / Reek warnings that have crept in.