### PR TITLE
Refactor #start and #footer

### DIFF
--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -44,20 +44,27 @@ module UpdateRepo
     #   walk_repo.start
     def start
       String.disable_colorization = true unless param_set('color')
-      no_import_export if dumping? && importing?
-      if importing?
-        Trollop.die "Sorry 'Import' functionality is not implemented yet".red
-      else
-        show_header
-        @config['location'].each do |loc|
-          recurse_dir(loc)
-        end
+      # make sure we dont have bad cmd-line parameter combinations ...
+      check_params
+      # print out our header ...
+      show_header unless dumping? || importing?
+      @config['location'].each do |loc|
+        recurse_dir(loc)
       end
-      # print out an informative footer...
-      footer unless dumping?
+      # print out an informative footer ...
+      footer unless dumping? || importing?
     end
 
     private
+
+    def check_params
+      if dumping? && importing?
+        Trollop.die 'Sorry, you cannot specify both --dump and --import '.red
+      end
+      if importing?
+        Trollop.die "Sorry 'Import' functionality is not implemented yet".red
+      end
+    end
 
     # Determine options from the command line and configuration file. Command
     # line takes precedence
@@ -135,7 +142,6 @@ EOS
     def show_header
       # print an informative header before starting
       # unless we are dumping the repo information
-      return if dumping?
       print "\nGit Repo update utility (v", VERSION, ')',
             " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
       print "Using Configuration from '#{@config.config_path}'\n"

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -210,7 +210,7 @@ EOS
             else
               print '   ', line.cyan
               # @metrics[:updated] += 1 if line =~ /files?\schanged/
-              @metrics[:updated] += 1 if line =~ /^From\shttps?:\/\//
+              @metrics[:updated] += 1 if line =~ %r{^From\shttps?://}
             end
           end
         end

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -54,7 +54,7 @@ module UpdateRepo
         end
       end
       # print out an informative footer...
-      footer
+      footer unless dumping?
     end
 
     private
@@ -152,8 +152,6 @@ EOS
     # print out a brief footer. This will be expanded later.
     # @return [void]
     def footer
-      # no footer if we are dumping the repo information
-      return if dumping?
       duration = Time.now - @metrics[:start_time]
       print "\nUpdates completed in ", show_time(duration).cyan
       print_metrics

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -34,17 +34,11 @@ module Helpers
 
   def show_time(duration)
     time_taken = Time.at(duration).utc
-    time_taken.strftime('%-H hours, %-M Minutes and %-S seconds.')
+    time_taken.strftime('%-H hours, %-M Minutes and %-S seconds')
   end
 
   # we cant use --dump and --import on the same command line
   def no_import_export
     Trollop.die 'update_repo : Cannot specify both --dump and --import'
-  end
-
-  # print the specified summary metric, called from the footer.
-  def summary(which, color, event)
-    output = "#{which} #{event}"
-    print ' / ', output.send(color.to_sym) unless which.zero?
   end
 end


### PR DESCRIPTION
Internally refactor the code for producing the footer summary output. Each metric is now specified in a hash, making it much easier to add more in future.

Moved the check for `dumping?` and `importing?` out of #header and #footer, this will be checked before actually calling those functions.

Refactor the #start function to simplify the logic and reduce the ABC complexity somewhat. Now passes both Rubocop and Reek. 

Also re-arrange the text order slightly, putting the elapsed time at the start instead of end.