### PR TITLE
Add logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .remote-sync.json
 .token
 .updatereporc
+updaterepo.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 .remote-sync.json
 .token
 .updatereporc
-updaterepo.log
+*.log

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Not in any specific order :
 - Add ability to specify a new directory (containing Git repos) to search from the command line, and optionally save this to the standard configuration.
 - Add new repo from the command line that will be cloned to the default repo directory and then updated as usual. Extra flag added for "add only, clone later" for offline use.
 - Add flag for 'default' repo directory (or another specific directory - if it does not already exist it will be created and added to the standard list) which will be used for new additions.
-- Option to save log file for each run.
 - Add option to only display a (text) tree of the discovered git repositories, not updating them; Similar option to just dump a list of the remote git locations.
 - Add Import & Export functionality :
   * ability to export a text dump of each repo location `[DONE]`

--- a/Rakefile
+++ b/Rakefile
@@ -35,4 +35,4 @@ else
   end
 end
 
-task default: [:rubocop, :inch, :reek, :spec, :build]
+task default: [:rubocop, :reek, :spec, :build]

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -115,7 +115,7 @@ EOS
         opt :prune, "Number of directory levels to remove from the --dump output.\nOnly valid when --dump or -d specified", default: 0
         opt :import, "Import a previous dump of directories and Git repository URL's,\n(created using --dump) then proceed to clone them locally.", default: false
         opt :log, "Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.", default: false
-        opt :timestamp, 'Timestamp the logfile instead of overwriting. Requires --log option to be set', default: false
+        opt :timestamp, 'Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.', default: false
         # opt :quiet, 'Only minimal output to the terminal', default: false
         # opt :silent, 'Completely silent, no output to terminal at all.', default: false
       end
@@ -156,7 +156,7 @@ EOS
       print_log "\nGit Repo update utility (v", VERSION, ')',
                 " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
       print_log "Using Configuration from '#{@config.config_path}'\n"
-      print_log "Command line is : #{@config['cmd']}\n"
+      # print_log "Command line is : #{@config['cmd']}\n"
       # list out the locations that will be searched
       list_locations
       # list any exceptions that we have from the config file

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -102,9 +102,9 @@ EOS
         opt :dump, 'Dump a list of Directories and Git URL\'s to STDOUT in CSV format', default: false
         opt :prune, "Number of directory levels to remove from the --dump output.\nOnly valid when --dump or -d specified", default: 0
         opt :import, "Import a previous dump of directories and Git repository URL's,\n(created using --dump) then proceed to clone them locally.", default: false
+        opt :log, "Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.", default: false
         # opt :quiet, 'Only minimal output to the terminal', default: false
-        # opt :silent, 'Completely silent, no output to terminal at all.',
-        #    default: false
+        # opt :silent, 'Completely silent, no output to terminal at all.', default: false
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -14,9 +14,6 @@ module Helpers
     File.join(path_array)
   end
 
-  # mark these as private simply so that 'reek' wont flag as utility function.
-  private
-
   # true if we are dumping the file structure and git urls instead of updating.
   def dumping?
     param_set('dump')
@@ -26,6 +23,23 @@ module Helpers
   def importing?
     param_set('import')
   end
+
+  # true if we are logging to file.
+  def logging?
+    param_set('log')
+  end
+
+  # this function will simply pass the given string to 'print', and also
+  # log to file if that is specified.
+  def print_log(*string)
+    # log to screen regardless
+    print(*string)
+    # log to file if that has been enabled
+    @logfile.write(string.join('').gsub(/\e\[(\d+)(;\d+)*m/, '')) if logging?
+  end
+
+  # mark these as private simply so that 'reek' wont flag as utility function.
+  private
 
   def gitdir?(dirpath)
     gitpath = dirpath + '/.git'

--- a/update_repo.gemspec
+++ b/update_repo.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'fakefs'
   spec.add_development_dependency 'json', '= 1.8.3'
+  spec.add_development_dependency 'tins', '= 1.6.0'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'inch'
   spec.add_development_dependency 'simplecov', '~> 0.10'


### PR DESCRIPTION
Add the ability to log all output to file when the `--log` or `-l` command line option is specified. By default this will be logged to `updaterepo.log` in the current directory, overwritten with each run of the program.

However, if the option `--timestamp` (or `-t`) is also specified, it will append a timestamp to this filename, allowing logs to be preserved between runs of the program. Specifying `--timestamp` without `--log` will be quietly ignored.

Later functionality will allow a custom filename and location for the log file.