### PR TITLE
Dump the URL's of all Repo remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Options:
                              Any older logs will be overwritten.
   -t, --timestamp            Timestamp the logfile instead of overwriting. Does nothing unless the
                              --log option is also specified.
+  -r, --dump-remote          Create a dump to screen or log listing all the git remote URLS found in
+                             the specified directories.
   -v, --version              Print version and exit
   -h, --help                 Show this message
 ```
@@ -105,9 +107,9 @@ Add functionality, not in any specific order :
 - Add ability to specify a new directory (containing Git repos) to search from the command line, and optionally save this to the standard configuration.
 - Add new repo from the command line that will be cloned to the default repo directory and then updated as usual. Extra flag added for "add only, clone later" for offline use.
 - Add flag for 'default' repo directory (or another specific directory - if it does not already exist it will be created and added to the standard list) which will be used for new additions.
-- Add option to only display a (text) tree of the discovered git repositories, not updating them; Similar option to just dump a list of the remote git locations.
+- Add option to only display a (text) tree of the discovered git repositories, not updating them.
 - Add Import & Export functionality :
-  * ability to export a text dump of each repo location `[DONE]`
+  * ability to export a text dump of each repo location and remote as a CSV file. `[DONE]`
   * re-import the above dump on a different machine or after reinstall
 - Add option to use alternative git command if required, either globally or on a case-by-case basis (see also comments on 'variants' above). Currently the script just uses a blanket `git pull` command on all repositories.
 - Document configuration file format and options. `[IN PROGRESS]`

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -40,7 +40,7 @@ module UpdateRepo
       # make sure we dont have bad cmd-line parameter combinations ...
       @cmd.check_params
       # print out our header unless we are dumping / importing ...
-      no_header = cmd(:dump) || cmd(:import)
+      no_header = cmd(:dump) || cmd(:import) || cmd(:dump_remote)
       show_header unless no_header
       config['location'].each do |loc|
         recurse_dir(loc)
@@ -77,7 +77,7 @@ module UpdateRepo
       Dir.chdir(dirname) do
         Dir['**/'].each do |dir|
           next unless gitdir?(dir)
-          if cmd(:dump)
+          if cmd(:dump) || cmd(:dump_remote)
             dump_repo(File.join(dirname, dir))
           else
             notexception?(dir) ? update_repo(dir) : skip_repo(dir)
@@ -187,10 +187,13 @@ module UpdateRepo
       end
     end
 
+    # this function will either dump out a CSV with the directory and remote,
+    # or just the remote depending if we called --dump or --dump-remote
     def dump_repo(dir)
       Dir.chdir(dir.chomp!('/')) do
         repo_url = `git config remote.origin.url`.chomp
-        print_log "#{trunc_dir(dir, config['cmd'][:prune])},#{repo_url}\n"
+        print_log "#{trunc_dir(dir, config['cmd'][:prune])}," if cmd(:dump)
+        print_log "#{repo_url}\n"
       end
     end
   end

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -21,6 +21,7 @@ module UpdateRepo
                                     prefix: 'update_repo',
                                     autoload: true, autosave: false)
       @conf['cmd'] = temp_opt
+      check_params
       config_error unless @conf.status[:errors] == Status::INFO_FILE_LOADED
     end
 
@@ -51,7 +52,10 @@ module UpdateRepo
     # make sure the parameter combinations are valid
     def check_params
       if true_cmd(:dump) && true_cmd(:import)
-        Trollop.die 'Sorry, you cannot specify both --dump and --import '.red
+        Trollop.die 'Sorry, you cannot specify --dump AND --import'.red
+      end
+      if true_cmd(:dump) && true_cmd(:dump_remote)
+        Trollop.die 'Sorry, you cannot specify --dump AND --dump-remote'.red
       end
     end
 
@@ -89,6 +93,7 @@ EOS
         # opt :import, "Import a previous dump of directories and Git repository URL's,\n(created using --dump) then proceed to clone them locally.", default: false
         opt :log, "Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.", default: false
         opt :timestamp, 'Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.', default: false
+        opt :dump_remote, 'Create a dump to screen or log listing all the git remote URLS found in the specified directories.', default: false, short: 'r'
         # opt :quiet, 'Only minimal output to the terminal', default: false
         # opt :silent, 'Completely silent, no output to terminal at all.', default: false
       end


### PR DESCRIPTION
This option `--dump-remotes` will produce a dump to STDOUT (and log if specified) simply listing ALL the git remote URL's that have been found in the specified directory structure.