### PR TITLE
Refactor logging and informative output

### DIFF
--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -45,7 +45,7 @@ module UpdateRepo
         cmd(:dump_tree) ? dump_tree(File.join(loc)) : recurse_dir(loc)
       end
       # print out an informative footer unless dump / import ...
-      footer unless dumping?
+      show_footer unless dumping?
     end
 
     private
@@ -70,20 +70,6 @@ module UpdateRepo
     #   logging = cmd(:log)
     def cmd(command)
       @cmd.true_cmd(command.to_sym)
-    end
-
-    # Set up the log file - determine if we need to timestamp the filename and
-    # then actually open it and set to sync.
-    # @param [none]
-    # @return [void]
-    def setup_logfile
-      filename = if cmd(:timestamp)
-                   'updaterepo-' + Time.new.strftime('%y%m%d-%H%M%S') + '.log'
-                 else
-                   'updaterepo.log'
-                 end
-      @logfile = File.open(filename, 'w')
-      @logfile.sync = true
     end
 
     # take each directory contained in the Repo directory, if it is detected as
@@ -133,7 +119,7 @@ module UpdateRepo
     # print out a brief footer. This will be expanded later.
     # @return [void]
     # @param [none]
-    def footer
+    def show_footer
       duration = Time.now - @metrics[:start_time]
       print_log "\nUpdates completed in ", show_time(duration).cyan
       print_metrics
@@ -152,7 +138,10 @@ module UpdateRepo
         print_log ' | ', output.send(color.to_sym) unless metric_value.zero?
       end
       print_log ' |'
-      return if @metrics[:failed_list].empty?
+      list_failures unless @metrics[:failed_list].empty?
+    end
+
+    def list_failures
       print_log "\n\n!! Note : The following repositories ",
                 'FAILED'.red.underline, ' during this run :'
       @metrics[:failed_list].each do |failed|

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -47,11 +47,14 @@ module UpdateRepo
       show_footer unless dumping?
     end
 
-    private
-
+    # helper function to call the Logger class output method.
+    # @param *string [Array] Array of strings to be passed to the 'print' fn
+    # @return [*string] Output of the Logger
     def print_log(*string)
       @log.output(*string)
     end
+
+    private
 
     def dumping?
       cmd(:dump) || cmd(:dump_remote) || cmd(:dump_tree)

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -1,6 +1,7 @@
 require 'update_repo/version'
 require 'update_repo/helpers'
 require 'update_repo/cmd_config'
+require 'update_repo/logger'
 require 'yaml'
 require 'colorize'
 require 'confoog'
@@ -28,7 +29,7 @@ module UpdateRepo
       # create a new instance of the CmdConfig class then read the config var
       @cmd = CmdConfig.new
       # set up the logfile if needed
-      setup_logfile if cmd(:log)
+      @log = Logger.new(cmd(:log), cmd(:timestamp))
     end
 
     # This function will perform the required actions to traverse the Repo.
@@ -49,6 +50,10 @@ module UpdateRepo
     end
 
     private
+
+    def print_log(*string)
+      @log.output(*string)
+    end
 
     def dumping?
       cmd(:dump) || cmd(:dump_remote) || cmd(:dump_tree)
@@ -106,7 +111,6 @@ module UpdateRepo
       print_log "\nGit Repo update utility (v", VERSION, ')',
                 " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
       print_log "Using Configuration from '#{config.config_path}'\n"
-      # print_log "Command line is : #{config['cmd']}\n"
       # list out the locations that will be searched
       list_locations
       # list any exceptions that we have from the config file
@@ -125,7 +129,7 @@ module UpdateRepo
       print_metrics
       print_log " \n\n"
       # close the log file now as we are done, just to be sure ...
-      @logfile.close if @logfile
+      @log.close
     end
 
     # Print end-of-run metrics to console / log

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -38,8 +38,6 @@ module UpdateRepo
     #   walk_repo.start
     def start
       String.disable_colorization = !cmd(:color)
-      # make sure we dont have bad cmd-line parameter combinations ...
-      @cmd.check_params # TODO - check this since is already called in @cmd.init
       # print out our header unless we are dumping / importing ...
       show_header unless dumping?
       config['location'].each do |loc|

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -28,6 +28,7 @@ module UpdateRepo
       @cmd = CmdConfig.new
       # set up the logfile if needed
       @log = Logger.new(cmd(:log), cmd(:timestamp))
+      # instantiate the console output class for header, footer etc
       @cons = ConsoleOutput.new(@log, @metrics, @cmd)
     end
 

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -60,12 +60,8 @@ module UpdateRepo
     # @return [void]
     def check_params
       return unless true_cmd(:dump)
-      # if  true_cmd(:import)
       Trollop.die 'You cannot use --dump AND --import'.red if true_cmd(:import)
-      # end
-      # if true_cmd(:dump_remote)
       Trollop.die 'You cannot use --dump AND --dump-remote'.red if true_cmd(:dump_remote)
-      # end
     end
     # rubocop:enable  Metrics/LineLength
 

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -8,9 +8,9 @@ module UpdateRepo
     include Helpers
 
     # Constructor for the ConsoleOutput class.
-    # @param logger [instance] Pointer to the Logger class
-    # @param metrics [hash] Hash of metrics and their output colors
-    # @param config [instance] Pointer to the Confoog class
+    # @param logger [class] Pointer to the Logger class
+    # @param metrics [hash] Hash of metrics and their values
+    # @param config [class] Pointer to the Confoog class
     # @return [void]
     # @example
     #   console = ConsoleOutput.new(@log)

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -1,0 +1,101 @@
+require 'update_repo/version'
+require 'update_repo/helpers'
+
+module UpdateRepo
+  # Class : ConsoleOutput.
+  # This class has functions to print header, footer and metrics.
+  class ConsoleOutput
+    include Helpers
+
+    # Constructor for the ConsoleOutput class.
+    # @param logger [instance] Pointer to the Logger class
+    # @param metrics [hash] Hash of metrics and their output colors
+    # @param config [instance] Pointer to the Confoog class
+    # @return [void]
+    # @example
+    #   console = ConsoleOutput.new(@log)
+    def initialize(logger, metrics, config)
+      @summary = { processed: 'green', updated: 'cyan', skipped: 'yellow',
+                   failed: 'red' }
+      @metrics = metrics
+      @log = logger
+      @config = config.getconfig
+    end
+
+    # Display a simple header to the console
+    # @example
+    #   show_header
+    # @return [void]
+    # @param [none]
+    def show_header
+      # print an informative header before starting
+      print_log "\nGit Repo update utility (v", VERSION, ')',
+                " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
+      print_log "Using Configuration from '#{@config.config_path}'\n"
+      # list out the locations that will be searched
+      list_locations
+      # list any exceptions that we have from the config file
+      list_exceptions
+      # save the start time for later display in the footer...
+      @metrics[:start_time] = Time.now
+      print_log "\n" # blank line before processing starts
+    end
+
+    # print out a brief footer. This will be expanded later.
+    # @return [void]
+    # @param [none]
+    def show_footer
+      duration = Time.now - @metrics[:start_time]
+      print_log "\nUpdates completed in ", show_time(duration).cyan
+      print_metrics
+      print_log " \n\n"
+      # close the log file now as we are done, just to be sure ...
+      @log.close
+    end
+
+    # Print end-of-run metrics to console / log
+    # @return [void]
+    # @param [none]
+    def print_metrics
+      @summary.each do |metric, color|
+        metric_value = @metrics[metric]
+        output = "#{metric_value} #{metric.capitalize}"
+        print_log ' | ', output.send(color.to_sym) unless metric_value.zero?
+      end
+      print_log ' |'
+      list_failures unless @metrics[:failed_list].empty?
+    end
+
+    # List any repositories that failed their update, and the error.
+    # @param [none]
+    # @return [void]
+    def list_failures
+      print_log "\n\n!! Note : The following repositories ",
+                'FAILED'.red.underline, ' during this run :'
+      @metrics[:failed_list].each do |failed|
+        print_log "\n  [", 'x'.red, "] #{failed[:loc]}"
+        print_log "\n    -> ", "\"#{failed[:line].chomp}\"".red
+      end
+    end
+
+    # Print a list of any defined expections that will not be updated.
+    # @return [void]
+    # @param [none]
+    def list_exceptions
+      exceptions = @config['exceptions']
+      return unless exceptions
+      print_log "\nExclusions:".underline, ' ',
+                exceptions.join(', ').yellow, "\n"
+    end
+
+    # Print a list of all top-level directories that will be searched and any
+    # Git repos contained within updated.
+    # @return [void]
+    def list_locations
+      print_log "\nRepo location(s):\n".underline
+      @config['location'].each do |loc|
+        print_log '-> ', loc.cyan, "\n"
+      end
+    end
+  end
+end

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -37,4 +37,18 @@ module Helpers
     time_taken = Time.at(duration).utc
     time_taken.strftime('%-H hours, %-M Minutes and %-S seconds')
   end
+
+  # Set up the log file - determine if we need to timestamp the filename and
+  # then actually open it and set to sync.
+  # @param [none]
+  # @return [void]
+  def setup_logfile
+    filename = if cmd(:timestamp)
+                 'updaterepo-' + Time.new.strftime('%y%m%d-%H%M%S') + '.log'
+               else
+                 'updaterepo.log'
+               end
+    @logfile = File.open(filename, 'w')
+    @logfile.sync = true
+  end
 end

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -14,17 +14,6 @@ module Helpers
     File.join(path_array)
   end
 
-  # this function will simply pass the given string to 'print', and also
-  # log to file if that is specified.
-  # @param string [array] Array of strings for print formatting
-  # @return [void]
-  def print_log(*string)
-    # log to screen regardless
-    print(*string)
-    # log to file if that has been enabled
-    @logfile.write(string.join('').gsub(/\e\[(\d+)(;\d+)*m/, '')) if cmd('log')
-  end
-
   # mark these as private simply so that 'reek' wont flag as utility function.
   private
 
@@ -36,19 +25,5 @@ module Helpers
   def show_time(duration)
     time_taken = Time.at(duration).utc
     time_taken.strftime('%-H hours, %-M Minutes and %-S seconds')
-  end
-
-  # Set up the log file - determine if we need to timestamp the filename and
-  # then actually open it and set to sync.
-  # @param [none]
-  # @return [void]
-  def setup_logfile
-    filename = if cmd(:timestamp)
-                 'updaterepo-' + Time.new.strftime('%y%m%d-%H%M%S') + '.log'
-               else
-                 'updaterepo.log'
-               end
-    @logfile = File.open(filename, 'w')
-    @logfile.sync = true
   end
 end

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -26,4 +26,11 @@ module Helpers
     time_taken = Time.at(duration).utc
     time_taken.strftime('%-H hours, %-M Minutes and %-S seconds')
   end
+
+  # helper function to call the Logger class output method.
+  # @param *string [Array] Array of strings to be passed to the 'print' fn
+  # @return [*string] Output of the Logger
+  def print_log(*string)
+    @log.output(*string)
+  end
 end

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -1,0 +1,13 @@
+require 'update_repo/version'
+require 'update_repo/helpers'
+
+module UpdateRepo
+  class Logger
+    include helpers
+
+    def initialize
+
+    end
+
+  end
+end

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -2,12 +2,56 @@ require 'update_repo/version'
 require 'update_repo/helpers'
 
 module UpdateRepo
+  # Class : Logger.
+  # This class encapsulates printing to screen and logging to file if requried.
   class Logger
-    include helpers
+    include Helpers
 
-    def initialize
-
+    # Constructor for the Logger class.
+    # @param enabled [boolean] True if we log to file
+    # @param timestamp [boolean] True if we timestamp the filename
+    # @return [void]
+    # @example
+    #   log = Logger.new(true, false)
+    def initialize(enabled, timestamp)
+      @settings = { enabled: enabled, timestamp: timestamp }
+      # don't prepare a logfile unless it's been requested.
+      return unless @settings[:enabled]
+      # generate a filename depending on 'timestamp' setting.
+      filename = generate_filename
+      # open the logfile and set sync mode.
+      @logfile = File.open(filename, 'w')
+      @logfile.sync = true
     end
 
+    # generate a filename for the log, with or without a timestamp
+    # @param [none]
+    # @return [string] Filename for the logfile.
+    def generate_filename
+      if @settings[:timestamp]
+        'updaterepo-' + Time.new.strftime('%y%m%d-%H%M%S') + '.log'
+      else
+        'updaterepo.log'
+      end
+    end
+
+    # this function will simply pass the given string to 'print', and also
+    # log to file if that is specified.
+    # @param string [array] Array of strings for print formatting
+    # @return [void]
+    def output(*string)
+      # log to screen regardless
+      print(*string)
+      # log to file if that has been enabled
+      return unless @settings[:enabled]
+      @logfile.write(string.join('').gsub(/\e\[(\d+)(;\d+)*m/, ''))
+    end
+
+    # close the logfile, if it exists
+    # @param [none]
+    # @return [void]
+    def close
+      @logfile.close if @logfile
+    end
   end
 end


### PR DESCRIPTION
* Split the logging implementation out to a separate class.
* Split the header, footer and metrics reports out to a separate class.
* General tidying and refactoring, remove old commented-out code

As a result of the above, several Rubocop & reek errors are fixed.