### PR TITLE
Quiet output

### DIFF
--- a/.reek
+++ b/.reek
@@ -1,6 +1,8 @@
 ---
 TooManyStatements:
-  max_statements: 10
+  max_statements: 8
+  exclude:
+  - set_options
 
 UtilityFunction:
   public_methods_only: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.1
-  - 2.2.4
+  - 1.9.3-p551
+  - 2.0.0-p648
+  - 2.1.10
+  - 2.2.5
   - 2.3.1
 before_install: gem install bundler -v 1.13.2

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -107,7 +107,7 @@ module UpdateRepo
         repo_url = `git config remote.origin.url`.chomp
         print_log '* Skipping ', Dir.pwd.yellow, " (#{repo_url})\n"
         @metrics[:skipped] += 1
-        @log.repostat({skipped: true})
+        @log.repostat(skipped: true)
         @metrics[:processed] += 1
       end
     end

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -119,7 +119,7 @@ module UpdateRepo
     def update_repo(dirname)
       Dir.chdir(dirname.chomp!('/')) do
         # create the git instance and then perform the update
-        @git = GitControl.new(repo_url, @log)
+        @git = GitControl.new(repo_url, @log, @metrics)
         @git.update
         @metrics[:processed] += 1
         # update the metrics

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -128,7 +128,6 @@ module UpdateRepo
     # @param none
     # @return [void]
     def do_update
-      # repo_url = `git config remote.origin.url`.chomp
       print_log '* Checking ', Dir.pwd.green, " (#{repo_url})\n"
       Open3.popen3('git pull') do |stdin, stdout, stderr, thread|
         stdin.close

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -119,13 +119,13 @@ module UpdateRepo
     def update_repo(dirname)
       Dir.chdir(dirname.chomp!('/')) do
         # create the git instance and then perform the update
-        @git = GitControl.new(repo_url, @log, @metrics)
-        @git.update
+        git = GitControl.new(repo_url, @log, @metrics)
+        git.update
         @metrics[:processed] += 1
         # update the metrics
-        @metrics[:updated] += 1 if @git.status[:updated]
-        @metrics[:failed] += 1 if @git.status[:failed]
-        @metrics[:unchanged] += 1 if @git.status[:unchanged]
+        [:failed, :updated, :unchanged].each do |metric|
+          @metrics[metric] += 1 if git.status[metric]
+        end
       end
     end
 

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -107,6 +107,7 @@ module UpdateRepo
         repo_url = `git config remote.origin.url`.chomp
         print_log '* Skipping ', Dir.pwd.yellow, " (#{repo_url})\n"
         @metrics[:skipped] += 1
+        @log.repostat({skipped: true})
         @metrics[:processed] += 1
       end
     end
@@ -127,6 +128,7 @@ module UpdateRepo
         [:failed, :updated, :unchanged].each do |metric|
           @metrics[metric] += 1 if git.status[metric]
         end
+        @log.repostat(git.status)
       end
     end
 

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -107,6 +107,7 @@ module UpdateRepo
         repo_url = `git config remote.origin.url`.chomp
         print_log '* Skipping ', Dir.pwd.yellow, " (#{repo_url})\n"
         @metrics[:skipped] += 1
+        @metrics[:processed] += 1
       end
     end
 

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -26,7 +26,7 @@ module UpdateRepo
       # create a new instance of the CmdConfig class then read the config var
       @cmd = CmdConfig.new
       # set up the output and logging class
-      @log = Logger.new(cmd(:log), cmd(:timestamp), cmd(:verbose))
+      @log = Logger.new(cmd(:log), cmd(:timestamp), cmd(:verbose), cmd(:quiet))
       # create instance of the Metrics class
       @metrics = Metrics.new(@log)
       # instantiate the console output class for header, footer etc

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -26,7 +26,7 @@ module UpdateRepo
       # create a new instance of the CmdConfig class then read the config var
       @cmd = CmdConfig.new
       # set up the output and logging class
-      @log = Logger.new(cmd(:log), cmd(:timestamp))
+      @log = Logger.new(cmd(:log), cmd(:timestamp), cmd(:verbose))
       # create instance of the Metrics class
       @metrics = Metrics.new(@log)
       # instantiate the console output class for header, footer etc

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -101,14 +101,14 @@ Options:
 EOS
         opt :color, 'Use colored output', default: true
         opt :dump, 'Dump a list of Directories and Git URL\'s to STDOUT in CSV format', default: false
-        opt :prune, "Number of directory levels to remove from the --dump output.\nOnly valid when --dump or -d specified", default: 0
+        opt :prune, "Number of directory levels to remove from the --dump output.\nOnly valid when --dump or -d specified.", default: 0
         # opt :import, "Import a previous dump of directories and Git repository URL's,\n(created using --dump) then proceed to clone them locally.", default: false
         opt :log, "Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.", default: false
         opt :timestamp, 'Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.', default: false
         opt :dump_remote, 'Create a dump to screen or log, listing all the git remote URLS found in the specified directories.', default: false, short: 'r'
         opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format.', default: false, short: 'u'
         opt :verbose, 'Display each repository and the git output to screen', default: false, short: 'V'
-        # opt :quiet, 'Only minimal output to the terminal', default: false
+        opt :quiet, 'Run completely silent, with no output to the terminal (except fatal errors).', default: false
         # opt :silent, 'Completely silent, no output to terminal at all.', default: false
       end
     end

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -107,6 +107,7 @@ EOS
         opt :timestamp, 'Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.', default: false
         opt :dump_remote, 'Create a dump to screen or log, listing all the git remote URLS found in the specified directories.', default: false, short: 'r'
         opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format.', default: false, short: 'u'
+        opt :verbose, 'Display each repository and the git output to screen', default: false, short: 'V'
         # opt :quiet, 'Only minimal output to the terminal', default: false
         # opt :silent, 'Completely silent, no output to terminal at all.', default: false
       end

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -38,6 +38,7 @@ module UpdateRepo
     # both command line (given preference) and the configuration file.
     # @param command [symbol] The symbol of the defined command
     # @return [various] Returns the true value of the comamnd symbol
+    # ignore the :reek:NilCheck for this function
     def true_cmd(command)
       cmd_given = @conf['cmd'][(command.to_s + '_given').to_sym]
       cmd_line = @conf['cmd'][command.to_sym]

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -16,7 +16,7 @@ module UpdateRepo
     #   console = ConsoleOutput.new(@log)
     def initialize(logger, metrics, config)
       @summary = { processed: 'green', updated: 'cyan', skipped: 'yellow',
-                   failed: 'red' }
+                   failed: 'red', unchanged: 'white' }
       @metrics = metrics
       @log = logger
       @config = config.getconfig

--- a/lib/update_repo/git_control.rb
+++ b/lib/update_repo/git_control.rb
@@ -62,6 +62,7 @@ module UpdateRepo
     # print a git output line and update the metrics if an update has occurred
     # @param line [string] The string containing the git output line
     # @return [void]
+    # rubocop:disable Metrics/LineLength
     def handle_output(line)
       print_log '   ', line.cyan
       @status[:updated] = true if line =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/

--- a/lib/update_repo/git_control.rb
+++ b/lib/update_repo/git_control.rb
@@ -9,8 +9,16 @@ module UpdateRepo
   class GitControl
     include Helpers
 
+    # @return [hash] Return the status hash
     attr_reader :status
 
+    # Constructor for the GitControl class.
+    # @param repo [string] Repo name
+    # @param logger [instance] pointer to the Logger class
+    # @param metrics [instance] pointer to the Metrics class
+    # @return [void]
+    # @example
+    #   git = GitControl.new(repo_url, @logger, @metrics)
     def initialize(repo, logger, metrics)
       @status = { updated: false, failed: false, unchanged: false }
       @repo = repo
@@ -18,6 +26,9 @@ module UpdateRepo
       @metrics = metrics
     end
 
+    # Update the git repo that was specified in the initializer.
+    # @param [none]
+    # @return [void]
     def update
       print_log '* Checking ', Dir.pwd.green, " (#{repo_url})\n"
       Open3.popen3('git pull') do |stdin, stdout, stderr, thread|

--- a/lib/update_repo/git_control.rb
+++ b/lib/update_repo/git_control.rb
@@ -1,0 +1,70 @@
+require 'update_repo/version'
+require 'update_repo/helpers'
+require 'open3'
+
+module UpdateRepo
+  # Class : GitControl.
+  # This class will update one git repo, and send the output to the logger.
+  # It will also return status of the operation in #status.
+  class GitControl
+    include Helpers
+
+    attr_reader :status
+
+    def initialize(repo, logger)
+      @status = { updated: false, failed: false, unchanged: false }
+      @repo = repo
+      @log = logger
+    end
+
+    def update
+      print_log '* Checking ', Dir.pwd.green, " (#{repo_url})\n"
+      Open3.popen3('git pull') do |stdin, stdout, stderr, thread|
+        stdin.close
+        do_threads(stdout, stderr)
+        thread.join
+      end
+      # reset the updated status in the rare case than both update and failed
+      # are set. This does happen!
+      @status[:updated] = false if @status[:updated] && @status[:failed]
+    end
+
+    private
+
+    # Create 2 individual threads to handle both STDOUT and STDERR streams,
+    # writing to console and log if specified.
+    # @param stdout [stream] STDOUT Stream from the popen3 call
+    # @param stderr [stream] STDERR Stream from the popen3 call
+    # @return [void]
+    def do_threads(stdout, stderr)
+      { out: stdout, err: stderr }.each do |key, stream|
+        Thread.new do
+          while (line = stream.gets)
+            handle_err(line, @status) if key == :err
+            handle_output(line, @status) if key == :out
+          end
+        end
+      end
+    end
+
+    # output an error line and update the metrics
+    # @param line [string] The string containing the error message
+    # @return [void]
+    def handle_err(line, status)
+      return unless line =~ /^fatal:|^error:/
+      print_log '   ', line.red
+      status[:failed] = true
+      err_loc = Dir.pwd + " (#{@repo})"
+      # @metrics[:failed_list].push(loc: err_loc, line: line)
+    end
+
+    # print a git output line and update the metrics if an update has occurred
+    # @param line [string] The string containing the git output line
+    # @return [void]
+    def handle_output(line, status)
+      print_log '   ', line.cyan
+      status[:updated] = true if line =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
+      status[:unchanged] = true if line =~ /^Already up-to-date./
+    end
+  end
+end

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -43,6 +43,7 @@ module UpdateRepo
     # @param string [array] Array of strings for print formatting
     # @return [void]
     def output(*string)
+      # nothing to screen if we want to be --quiet
       unless @settings[:quiet]
         # log header and footer to screen regardless, others only if verbose
         if @settings[:verbose] || !repo_text?
@@ -56,7 +57,6 @@ module UpdateRepo
           when 'handle_err'
             print 'x'.red
           when 'handle_output'
-            # print string
             if string =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
               print '^'.green
             elsif string =~ /Already up-to-date./

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -45,29 +45,18 @@ module UpdateRepo
     def output(*string)
       # nothing to screen if we want to be --quiet
       unless @settings[:quiet]
-        # log header and footer to screen regardless, others only if verbose
-        if @settings[:verbose] || !repo_text?
-          print(*string)
-        else
-          # remove control characters from the string...
-          string = string.join.gsub(/\e\[(\d+)(;\d+)*m/, '').strip
-          case repo_text?
-          when 'skip_repo'
-            print 's'.yellow
-          when 'handle_err'
-            print 'x'.red
-          when 'handle_output'
-            if string =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
-              print '^'.green
-            elsif string =~ /Already up-to-date./
-              print '.'
-            end
-          end
-        end
+        # log header and footer to screen regardless
+        print(*string) if @settings[:verbose] || !repo_text?
       end
       # log to file if that has been enabled
       return unless @settings[:enabled]
       @logfile.write(string.join('').gsub(/\e\[(\d+)(;\d+)*m/, ''))
+    end
+
+    def repostat(char, color)
+      # only print if not quiet and not verbose!
+      return if @settings[:quiet] or @settings[:verbose]
+      print char.send(color.to_sym)
     end
 
     # returns non nil if we have been called originally by one of the Repo

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -55,8 +55,7 @@ module UpdateRepo
 
     # function repostat - outputs the passed char at the passed color,
     # only if we are not in quiet nor verbose mode.
-    # @param char [char] One single chjar to be output
-    # @param color [string] The color to display the char in
+    # @param status [hash] pointer to GitControl.status hash
     # @return [void]
     def repostat(status)
       # only print if not quiet and not verbose!

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -55,7 +55,7 @@ module UpdateRepo
 
     def repostat(char, color)
       # only print if not quiet and not verbose!
-      return if @settings[:quiet] or @settings[:verbose]
+      return if @settings[:quiet] || @settings[:verbose]
       print char.send(color.to_sym)
     end
 
@@ -69,7 +69,7 @@ module UpdateRepo
       calling_fn = caller_locations[2].label.gsub(/block in /, '')
 
       # array with the functions we want to skip
-      repo_output = %w(do_update handle_output handle_err skip_repo)
+      repo_output = %w(do_update handle_output handle_err skip_repo update)
 
       # return the name in string if DOES match.
       calling_fn if repo_output.include?(calling_fn)

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -53,6 +53,11 @@ module UpdateRepo
       @logfile.write(string.join('').gsub(/\e\[(\d+)(;\d+)*m/, ''))
     end
 
+    # function repostat - outputs the passed char at the passed color,
+    # only if we are not in quiet nor verbose mode.
+    # @param char [char] One single chjar to be output
+    # @param color [string] The color to display the char in
+    # @return [void]
     def repostat(char, color)
       # only print if not quiet and not verbose!
       return if @settings[:quiet] || @settings[:verbose]

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -58,10 +58,18 @@ module UpdateRepo
     # @param char [char] One single chjar to be output
     # @param color [string] The color to display the char in
     # @return [void]
-    def repostat(char, color)
+    def repostat(status)
       # only print if not quiet and not verbose!
       return if @settings[:quiet] || @settings[:verbose]
-      print char.send(color.to_sym)
+      if status[:failed]
+        print 'x'.red
+      elsif status[:updated]
+        print '^'.green
+      elsif status[:unchanged]
+        print '.'
+      elsif status[:skipped]
+        print 's'.yellow
+      end
     end
 
     # returns non nil if we have been called originally by one of the Repo

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -11,11 +11,13 @@ module UpdateRepo
     # @param enabled [boolean] True if we log to file
     # @param timestamp [boolean] True if we timestamp the filename
     # @param verbose [boolean] True if verbose flag is set
+    # @param quiet [boolean] True if quiet flag is set
     # @return [void]
     # @example
     #   log = Logger.new(true, false)
-    def initialize(enabled, timestamp, verbose)
-      @settings = { enabled: enabled, timestamp: timestamp, verbose: verbose }
+    def initialize(enabled, timestamp, verbose, quiet)
+      @settings = { enabled: enabled, timestamp: timestamp, verbose: verbose,
+                    quiet: quiet }
       # don't prepare a logfile unless it's been requested.
       return unless @settings[:enabled]
       # generate a filename depending on 'timestamp' setting.
@@ -41,23 +43,25 @@ module UpdateRepo
     # @param string [array] Array of strings for print formatting
     # @return [void]
     def output(*string)
-      # log header and footer to screen regardless, others only if verbose
-      if @settings[:verbose] || !repo_text?
-        print(*string)
-      else
-        # remove control characters from the string...
-        string = string.join.gsub(/\e\[(\d+)(;\d+)*m/, '').strip
-        case repo_text?
-        when 'skip_repo'
-          print 's'.yellow
-        when 'handle_err'
-          print 'x'.red
-        when 'handle_output'
-          # print string
-          if string =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
-            print '^'.green
-          elsif string =~ /Already up-to-date./
-            print '.'
+      unless @settings[:quiet]
+        # log header and footer to screen regardless, others only if verbose
+        if @settings[:verbose] || !repo_text?
+          print(*string)
+        else
+          # remove control characters from the string...
+          string = string.join.gsub(/\e\[(\d+)(;\d+)*m/, '').strip
+          case repo_text?
+          when 'skip_repo'
+            print 's'.yellow
+          when 'handle_err'
+            print 'x'.red
+          when 'handle_output'
+            # print string
+            if string =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
+              print '^'.green
+            elsif string =~ /Already up-to-date./
+              print '.'
+            end
           end
         end
       end

--- a/lib/update_repo/metrics.rb
+++ b/lib/update_repo/metrics.rb
@@ -47,7 +47,6 @@ module UpdateRepo
     # @return [void]
     def handle_output(line)
       print_log '   ', line.cyan
-      # @metrics[:updated] += 1 if line =~ %r{^From\s(?:https?|git)://}
       @metrics[:updated] += 1 if line =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
     end
   end

--- a/lib/update_repo/metrics.rb
+++ b/lib/update_repo/metrics.rb
@@ -47,7 +47,8 @@ module UpdateRepo
     # @return [void]
     def handle_output(line)
       print_log '   ', line.cyan
-      @metrics[:updated] += 1 if line =~ %r{^From\s(?:https?|git)://}
+      # @metrics[:updated] += 1 if line =~ %r{^From\s(?:https?|git)://}
+      @metrics[:updated] += 1 if line =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
     end
   end
 end

--- a/lib/update_repo/metrics.rb
+++ b/lib/update_repo/metrics.rb
@@ -13,7 +13,7 @@ module UpdateRepo
     def initialize(logger)
       @log = logger
       @metrics = { processed: 0, skipped: 0, failed: 0, updated: 0,
-                   start_time: 0, failed_list: [] }
+                   unchanged: 0, start_time: 0, failed_list: [] }
     end
 
     # Read the metric 'key'
@@ -29,25 +29,6 @@ module UpdateRepo
     # @return [value] Return the value set.
     def []=(key, value)
       @metrics[key] = value
-    end
-
-    # output an error line and update the metrics
-    # @param line [string] The string containing the error message
-    # @return [void]
-    def handle_err(line)
-      return unless line =~ /^fatal:|^error:/
-      print_log '   ', line.red
-      @metrics[:failed] += 1
-      err_loc = Dir.pwd + " (#{repo_url})"
-      @metrics[:failed_list].push(loc: err_loc, line: line)
-    end
-
-    # print a git output line and update the metrics if an update has occurred
-    # @param line [string] The string containing the git output line
-    # @return [void]
-    def handle_output(line)
-      print_log '   ', line.cyan
-      @metrics[:updated] += 1 if line =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
     end
   end
 end

--- a/update_repo.gemspec
+++ b/update_repo.gemspec
@@ -1,5 +1,6 @@
 # coding: utf-8
 # rubocop:disable LineLength
+# rubocop:disable Metrics/BlockLength
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'update_repo/version'


### PR DESCRIPTION
Add a less verbose output where each repo will only be displayed by a '.' or other character depending on it's status, and __make this the default option__. The old display is now the 'Verbose' mode and can be activated using the command line options `--verbose` or `-V`, or by adding `verbose: true` to the configuration file.

Also adds a completely quiet mode, where nothing is printed to the screen except fatal errors. This can be activated by the command line options `--quiet` or `-q`, or adding `quiet:true` to the configuration file.

Still a work in progress and should not be merged yet - the counts of updated repos can be too high if the Repo update fails in certain situations. This also adds an extra 'updated' to the non-verbose output in those cases.