### PR TITLE
Fix #24 (Refactor the whole repo update logic).

### DIFF
--- a/.reek
+++ b/.reek
@@ -12,3 +12,6 @@ RepeatedConditional:
 
 DuplicateMethodCall:
  max_calls: 3
+
+NestedIterators:
+  max_allowed_nesting: 2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ __Note:__ From version 0.9.0 onwards, the default mode of operation is non-verbo
 
 #### Pre-requirements
 
-It goes without saying that at the very least a working copy of both [`Git`][git] and [`Ruby`][ruby] need to be installed on your machine. Also, the script has currently only been tested under Linux, not windows.
+It goes without saying that at the very least a working copy of both [`Git`][git] (version 1.8.5 or greater, the script will not run with an older version) and [`Ruby`][ruby] need to be installed on your machine. Also, the script has currently only been tested under Linux, not windows.
 
 [git]: http://git-scm.com
 [ruby]: http://www.ruby-lang.org
@@ -152,7 +152,7 @@ Run `rake` to run the RSpec tests, which also runs `RuboCop`, `Reek` and `inch -
 5. Create new Pull Request
 
 Please note - This Gem currently aims to pass 100% on [RuboCop][rubocop], [Reek][reek] and [Inch-CI][inch] (on pedantic mode), so all pull requests should do likewise. Ask for guidance if needed.
-Running `rake` will automatically test all 3 of those along with the RSpec tests. Note that Failures of Rubocop will cause the CI (Travis) to fail, however 'Reek' failures will not.
+Running `rake` will automatically test all 3 of those along with the RSpec tests.
 
 [rubocop]: https://github.com/bbatsov/rubocop
 [reek]: https://github.com/troessner/reek

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -55,7 +55,8 @@ module UpdateRepo
 
     def checkgit
       unless which('git')
-        puts 'Git is not installed on this machine, script cannot continue.'.red
+        print 'Git is not installed on this machine, script cannot '.red,
+              "continue.\n".red
         exit 1
       end
       gitver = `git --version`.gsub(/git version /, '').chomp
@@ -91,6 +92,7 @@ module UpdateRepo
     # a Git repository then update it (or as directed by command line)
     # @param dirname [string] Contains the directory to search for Git repos.]
     # @return [void]
+    # rubocop:disable LineLength
     def recurse_dir(dirname)
       walk_tree(dirname).each do |repo|
         if dumping?
@@ -100,6 +102,7 @@ module UpdateRepo
         end
       end
     end
+    # rubocop:enable LineLength
 
     # walk the specified tree, return an array of hashes holding valid repos
     # @param dirname [string] Directory to use as the base of the search

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -9,6 +9,7 @@ require 'yaml'
 require 'colorize'
 require 'confoog'
 require 'trollop'
+require 'versionomy'
 
 # Overall module with classes performing the functionality
 # Contains Class UpdateRepo::WalkRepo
@@ -39,6 +40,8 @@ module UpdateRepo
     #   walk_repo.start
     def start
       String.disable_colorization = !cmd(:color)
+      # check for existence of 'Git' and exit otherwise...
+      checkgit
       # print out our header unless we are dumping / importing ...
       @cons.show_header unless dumping?
       config['location'].each do |loc|
@@ -49,6 +52,18 @@ module UpdateRepo
     end
 
     private
+
+    def checkgit
+      unless which('git')
+        puts 'Git is not installed on this machine, script cannot continue.'.red
+        exit 1
+      end
+      gitver = `git --version`.gsub(/git version /, '').chomp
+      return if Versionomy.parse(gitver) >= '1.8.5'
+      print 'Git version 1.8.5 or greater must be installed, you have '.red,
+            "version #{gitver}!\n".red
+      exit 1
+    end
 
     def dumping?
       cmd(:dump) || cmd(:dump_remote) || cmd(:dump_tree)

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -110,7 +110,6 @@ EOS
         opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format.', default: false, short: 'u'
         opt :verbose, 'Display each repository and the git output to screen', default: false, short: 'V'
         opt :quiet, 'Run completely silent, with no output to the terminal (except fatal errors).', default: false
-        # opt :silent, 'Completely silent, no output to terminal at all.', default: false
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -70,11 +70,10 @@ module UpdateRepo
     # @param [none]
     # @return [void]
     def list_failures
+      # ensure we don't have duplicate errors from the same repo
+      remove_dups
       print_log "\n\n!! Note : The following #{@metrics[:failed_list].count}",
                 ' repositories ', 'FAILED'.red.underline, ' during this run :'
-      # ensure we don't have duplicate errors from the same repo
-      # @metrics[:failed_list].uniq! { |x| x[:loc] }
-      remove_dups
       # print out any and all errors into a nice list
       @metrics[:failed_list].each do |failed|
         print_log "\n  [", 'x'.red, "] #{failed[:loc]}"
@@ -82,9 +81,12 @@ module UpdateRepo
       end
     end
 
+    # removes any duplications in the list of failed repos.
+    # @param [none]
+    # @return [void] modifies the @metrics[:failed_list] in place
     def remove_dups
       # removes duplicate ':loc' values from the Failed list.
-      @metrics[:failed_list].uniq! { |x| x[:loc] }
+      @metrics[:failed_list].uniq! { |error| error[:loc] }
     end
 
     # Print a list of any defined expections that will not be updated.

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -72,6 +72,9 @@ module UpdateRepo
     def list_failures
       print_log "\n\n!! Note : The following #{@metrics[:failed_list].count}",
                 ' repositories ', 'FAILED'.red.underline, ' during this run :'
+      # ensure we don't have duplicate errors from the same repo
+      @metrics[:failed_list].uniq! { |x| x[:loc] }
+      # print out any and all errors into a nice list
       @metrics[:failed_list].each do |failed|
         print_log "\n  [", 'x'.red, "] #{failed[:loc]}"
         print_log "\n    -> ", "\"#{failed[:line].chomp}\"".red

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -73,12 +73,18 @@ module UpdateRepo
       print_log "\n\n!! Note : The following #{@metrics[:failed_list].count}",
                 ' repositories ', 'FAILED'.red.underline, ' during this run :'
       # ensure we don't have duplicate errors from the same repo
-      @metrics[:failed_list].uniq! { |x| x[:loc] }
+      # @metrics[:failed_list].uniq! { |x| x[:loc] }
+      remove_dups
       # print out any and all errors into a nice list
       @metrics[:failed_list].each do |failed|
         print_log "\n  [", 'x'.red, "] #{failed[:loc]}"
         print_log "\n    -> ", "\"#{failed[:line].chomp}\"".red
       end
+    end
+
+    def remove_dups
+      # removes duplicate ':loc' values from the Failed list.
+      @metrics[:failed_list].uniq! { |x| x[:loc] }
     end
 
     # Print a list of any defined expections that will not be updated.

--- a/lib/update_repo/git_control.rb
+++ b/lib/update_repo/git_control.rb
@@ -31,10 +31,8 @@ module UpdateRepo
     # @return [void]
     def update
       print_log '* Checking ', @dir.green, " (#{repo_url})\n"
-      Open3.popen3("git -C #{@dir} pull") do |stdin, stdout, stderr, thread|
-        stdin.close
-        do_threads(stdout, stderr)
-        thread.join
+      Open3.popen2e("git -C #{@dir} pull") do |stdin, stdout_err, thread|
+        stdout_err.each { |line| handle_output(line) }
       end
       # reset the updated status in the rare case than both update and failed
       # are set. This does happen!
@@ -50,41 +48,21 @@ module UpdateRepo
       `git -C #{@dir} config remote.origin.url`.chomp
     end
 
-    # Create 2 individual threads to handle both STDOUT and STDERR streams,
-    # writing to console and log if specified.
-    # @param stdout [stream] STDOUT Stream from the popen3 call
-    # @param stderr [stream] STDERR Stream from the popen3 call
-    # @return [void]
-    def do_threads(stdout, stderr)
-      { out: stdout, err: stderr }.each do |key, stream|
-        Thread.new do
-          while (line = stream.gets)
-            handle_err(line) if key == :err
-            handle_output(line) if key == :out
-          end
-        end
-      end
-    end
-
-    # output an error line and update the metrics
-    # @param line [string] The string containing the error message
-    # @return [void]
-    def handle_err(line)
-      return unless line =~ /^fatal:|^error:/
-      print_log '   ', line.red
-      @status[:failed] = true
-      err_loc = "#{@dir} (#{repo_url})"
-      @metrics[:failed_list].push(loc: err_loc, line: line)
-    end
-
     # print a git output line and update the metrics if an update has occurred
     # @param line [string] The string containing the git output line
     # @return [void]
     # rubocop:disable Metrics/LineLength
     def handle_output(line)
-      print_log '   ', line.cyan
-      @status[:updated] = true if line =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
-      @status[:unchanged] = true if line =~ /^Already up-to-date./
+      if line.chomp =~ /^fatal:|^error:/
+        print_log '   ', line.red
+        @status[:failed] = true
+        err_loc = "#{@dir} (#{repo_url})"
+        @metrics[:failed_list].push(loc: err_loc, line: line)
+      else
+        print_log '   ', line.cyan
+        @status[:updated] = true if line =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
+        @status[:unchanged] = true if line =~ /^Already up-to-date./
+      end
     end
     # rubocop:enable Metrics/LineLength
   end

--- a/lib/update_repo/git_control.rb
+++ b/lib/update_repo/git_control.rb
@@ -31,7 +31,7 @@ module UpdateRepo
     # @return [void]
     def update
       print_log '* Checking ', @dir.green, " (#{repo_url})\n"
-      Open3.popen2e("git -C #{@dir} pull") do |stdin, stdout_err, thread|
+      Open3.popen2e("git -C #{@dir} pull") do |_stdin, stdout_err, _thread|
         stdout_err.each { |line| handle_output(line) }
       end
       # reset the updated status in the rare case than both update and failed

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -33,8 +33,4 @@ module Helpers
   def print_log(*string)
     @log.output(*string)
   end
-
-  def repo_url
-    `git config remote.origin.url`.chomp
-  end
 end

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -33,4 +33,19 @@ module Helpers
   def print_log(*string)
     @log.output(*string)
   end
+
+  # Cross-platform way of finding an executable in the $PATH.
+  # From : http://stackoverflow.com/a/5471032/6641755
+  #
+  #   which('ruby') #=> /usr/bin/ruby
+  def which(cmd)
+    exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+    ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+      exts.each do |ext|
+        exe = File.join(path, "#{cmd}#{ext}")
+        return exe if File.executable?(exe) && !File.directory?(exe)
+      end
+    end
+    # return nil
+  end
 end

--- a/update_repo.gemspec
+++ b/update_repo.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colorize'
   spec.add_dependency 'confoog'
   spec.add_dependency 'trollop'
+  spec.add_dependency 'versionomy'
   # on Ruby 1.9.3 we lock the 'term-ansicolor' gem to version 1.3.2
   spec.add_dependency 'term-ansicolor', '= 1.3.2' if RUBY_VERSION < '2.0'
 end


### PR DESCRIPTION
Now the script will not change directory before each git operation, we instead take advantage of the Git '-C' flag that allows us to perform the operation on a repo in a completely different directory. Note however that this needs Git version >= 1.8.5. Commit e7b2bf2 in this PR will check for this at script start up and fail gracefully if the version is too low. Should not be too much of an issue since most systems have a more recent version.

I have also removed the use of separate threads for stdout and stderr, and consolidated the display into a single function. As a result of this, we no longer get thread race conditions where the local directory may have been changed by a separate thread causing erroneous directories to be reported in the fail list.
This is the main factor to now getting consistent outputs over consecutive runs. This may generally make the whole script a little more stable but that needs more runs to be sure.

As the main purpose of this PR, it fixes issue #24 - Duplicates in the footer error list when a pull fails with both `error:` and `fatal:` messages

This commit also fixes a bug introduced by a previous commit that caused the
--dump and --dump-remotes to fail.
