### PR TITLE
Default to saving the log file in the users home directory.

### DIFF
--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -106,7 +106,7 @@ EOS
         # opt :import, "Import a previous dump of directories and Git repository URL's,\n(created using --dump) then proceed to clone them locally.", default: false
         opt :log, "Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.", default: false
         opt :timestamp, 'Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.', default: false
-        opt :log_local, 'Create the logfile in the current directory instead of in the users home directory', default: false, short: 'o'
+        # opt :log_local, 'Create the logfile in the current directory instead of in the users home directory', default: false, short: 'o'
         opt :dump_remote, 'Create a dump to screen or log, listing all the git remote URLS found in the specified directories.', default: false, short: 'r'
         opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format.', default: false, short: 'u'
         opt :verbose, 'Display each repository and the git output to screen', default: false, short: 'V'

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -106,6 +106,7 @@ EOS
         # opt :import, "Import a previous dump of directories and Git repository URL's,\n(created using --dump) then proceed to clone them locally.", default: false
         opt :log, "Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.", default: false
         opt :timestamp, 'Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.', default: false
+        opt :log_local, 'Create the logfile in the current directory instead of in the users home directory', default: false, short: 'o'
         opt :dump_remote, 'Create a dump to screen or log, listing all the git remote URLS found in the specified directories.', default: false, short: 'r'
         opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format.', default: false, short: 'u'
         opt :verbose, 'Display each repository and the git output to screen', default: false, short: 'V'

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -36,10 +36,11 @@ module UpdateRepo
     # @return [string] Filename for the logfile.
     def generate_filename
       if @settings[:timestamp]
-        'updaterepo-' + Time.new.strftime('%y%m%d-%H%M%S') + '.log'
+        name = 'updaterepo-' + Time.new.strftime('%y%m%d-%H%M%S') + '.log'
       else
-        'updaterepo.log'
+        name = 'updaterepo.log'
       end
+      File.expand_path(File.join('~/', name))
     end
 
     # this function will simply pass the given string to 'print', and also


### PR DESCRIPTION
Previously it was saved in whichever was the current directory at the time the script was run, leading to files left all over the place.

A future PR will allow the old behaviour to be chosen if required from a command line option, or actually specify a completely different location.
