### PR TITLE
Simplify internal param usage

### DIFF
--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -24,7 +24,7 @@ module UpdateRepo
       # create a new instance of the CmdConfig class then read the config var
       @cmd = CmdConfig.new
       # set up the output and logging class
-      @log = Logger.new(cmd(:log), cmd(:timestamp), cmd(:verbose), cmd(:quiet))
+      @log = Logger.new(@cmd)
       # create instance of the Metrics class
       @metrics = Metrics.new(@log)
       # instantiate the console output class for header, footer etc
@@ -36,13 +36,13 @@ module UpdateRepo
     #   walk_repo = UpdateRepo::WalkRepo.new
     #   walk_repo.start
     def start
-      String.disable_colorization = !cmd(:color)
+      String.disable_colorization = !@cmd[:color]
       # check for existence of 'Git' and exit otherwise...
       checkgit
       # print out our header unless we are dumping / importing ...
       @cons.show_header unless dumping?
       config['location'].each do |loc|
-        cmd(:dump_tree) ? dump_tree(File.join(loc)) : recurse_dir(loc)
+        @cmd[:dump_tree] ? dump_tree(File.join(loc)) : recurse_dir(loc)
       end
       # print out an informative footer unless dump / import ...
       @cons.show_footer unless dumping?
@@ -64,7 +64,7 @@ module UpdateRepo
     end
 
     def dumping?
-      cmd(:dump) || cmd(:dump_remote) || cmd(:dump_tree)
+      @cmd[:dump] || @cmd[:dump_remote] || @cmd[:dump_tree]
     end
 
     # returns the Confoog class which can then be used to access any config var
@@ -72,17 +72,6 @@ module UpdateRepo
     # @param [none]
     def config
       @cmd.getconfig
-    end
-
-    # Return the true value of the specified configuration parameter. This is a
-    # helper function that simply calls the 'true_cmd' function in the @cmd
-    # class
-    # @param command [symbol] The defined command symbol that is to be returned
-    # @return [various] The value of the requested command option
-    # @example
-    #   logging = cmd(:log)
-    def cmd(command)
-      @cmd.true_cmd(command.to_sym)
     end
 
     # take each directory contained in the Repo directory, if it is detected as
@@ -160,7 +149,7 @@ module UpdateRepo
     # @return [void]
     def dump_repo(dir)
       Dir.chdir(dir.chomp!('/')) do
-        print_log "#{trunc_dir(dir, config['cmd'][:prune])}," if cmd(:dump)
+        print_log "#{trunc_dir(dir, @cmd[:prune])}," if @cmd[:dump]
         print_log `git -C #{dir} config remote.origin.url`
       end
     end

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -40,6 +40,15 @@ module UpdateRepo
       @conf
     end
 
+    # return the specified TRUE configuration variable, using '[]' notation
+    # @param key [string] Which cmd variable to return
+    # @return [various] The value of the specified cmd variable
+    # @example
+    #   quiet = @cmd[quiet]
+    def [](key)
+      true_cmd(key.to_sym)
+    end
+
     # This will return the 'true' version of a command, taking into account
     # both command line (given preference) and the configuration file.
     # @param command [symbol] The symbol of the defined command

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -10,7 +10,7 @@ module UpdateRepo
     # Constructor for the ConsoleOutput class.
     # @param logger [class] Pointer to the Logger class
     # @param metrics [class] Pointer to the Metrics class
-    # @param config [class] Pointer to the Confoog class
+    # @param cmd [class] Pointer to the CmdConfig class
     # @return [void]
     # @example
     #   console = ConsoleOutput.new(@log)
@@ -112,6 +112,7 @@ module UpdateRepo
     end
 
     # print out the logfile name and location, if we are logging to file
+    # @return [void]
     def show_logfile
       return unless @cmd[:log]
       print_log "\nLogging to file:".underline, " #{@log.logfile}\n".cyan

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -33,7 +33,7 @@ module UpdateRepo
                 " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
       print_log "Using Configuration from '#{@cmd.getconfig.config_path}'\n"
       # show the logfile location, but only if it is enabled
-      show_logfile if @cmd[:log]
+      show_logfile
       # list out the locations that will be searched
       list_locations
       # list any exceptions that we have from the config file
@@ -111,7 +111,9 @@ module UpdateRepo
       end
     end
 
+    # print out the logfile name and location, if we are logging to file
     def show_logfile
+      return unless @cmd[:log]
       print_log "\nLogging to file:".underline, " #{@log.logfile}\n".cyan
     end
   end

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -14,12 +14,12 @@ module UpdateRepo
     # @return [void]
     # @example
     #   console = ConsoleOutput.new(@log)
-    def initialize(logger, metrics, config)
+    def initialize(logger, metrics, cmd)
       @summary = { processed: 'green', updated: 'cyan', skipped: 'yellow',
                    failed: 'red', unchanged: 'white' }
       @metrics = metrics
       @log = logger
-      @config = config.getconfig
+      @cmd = cmd
     end
 
     # Display a simple header to the console
@@ -31,7 +31,9 @@ module UpdateRepo
       # print an informative header before starting
       print_log "\nGit Repo update utility (v", VERSION, ')',
                 " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
-      print_log "Using Configuration from '#{@config.config_path}'\n"
+      print_log "Using Configuration from '#{@cmd.getconfig.config_path}'\n"
+      # show the logfile location, but only if it is enabled
+      show_logfile if @cmd[:log]
       # list out the locations that will be searched
       list_locations
       # list any exceptions that we have from the config file
@@ -93,7 +95,7 @@ module UpdateRepo
     # @return [void]
     # @param [none]
     def list_exceptions
-      exceptions = @config['exceptions']
+      exceptions = @cmd['exceptions']
       return unless exceptions
       print_log "\nExclusions:".underline, ' ',
                 exceptions.join(', ').yellow, "\n"
@@ -104,9 +106,13 @@ module UpdateRepo
     # @return [void]
     def list_locations
       print_log "\nRepo location(s):\n".underline
-      @config['location'].each do |loc|
+      @cmd['location'].each do |loc|
         print_log '-> ', loc.cyan, "\n"
       end
+    end
+
+    def show_logfile
+      print_log "\nLogging to file:".underline, " #{@log.logfile}\n".cyan
     end
   end
 end

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -8,22 +8,18 @@ module UpdateRepo
     include Helpers
 
     # Constructor for the Logger class.
-    # @param enabled [boolean] True if we log to file
-    # @param timestamp [boolean] True if we timestamp the filename
-    # @param verbose [boolean] True if verbose flag is set
-    # @param quiet [boolean] True if quiet flag is set
+    # @param cmd [instance] - pointer to the CmdConfig class
     # @return [void]
     # @example
-    #   log = Logger.new(true, false)
-    def initialize(enabled, timestamp, verbose, quiet)
-      @settings = { enabled: enabled, timestamp: timestamp, verbose: verbose,
-                    quiet: quiet }
+    #   log = Logger.new(@cmd)
+    def initialize(cmd)
+      @cmd = cmd
       @legend = { failed: { char: 'x', color: 'red' },
                   updated: { char: '^', color: 'green' },
                   unchanged: { char: '.', color: 'white' },
                   skipped: { char: 's', color: 'yellow' } }
       # don't prepare a logfile unless it's been requested.
-      return unless @settings[:enabled]
+      return unless @cmd[:log]
       # generate a filename depending on 'timestamp' setting.
       filename = generate_filename
       # open the logfile and set sync mode.
@@ -35,7 +31,7 @@ module UpdateRepo
     # @param [none]
     # @return [string] Filename for the logfile.
     def generate_filename
-      if @settings[:timestamp]
+      if @cmd[:timestamp]
         name = 'updaterepo-' + Time.new.strftime('%y%m%d-%H%M%S') + '.log'
       else
         name = 'updaterepo.log'
@@ -49,12 +45,12 @@ module UpdateRepo
     # @return [void]
     def output(*string)
       # nothing to screen if we want to be --quiet
-      unless @settings[:quiet]
+      unless @cmd[:quiet]
         # log header and footer to screen regardless
-        print(*string) if @settings[:verbose] || !repo_text?
+        print(*string) if @cmd[:verbose] || !repo_text?
       end
       # log to file if that has been enabled
-      return unless @settings[:enabled]
+      return unless @cmd[:log]
       @logfile.write(string.join('').gsub(/\e\[(\d+)(;\d+)*m/, ''))
     end
 
@@ -64,7 +60,7 @@ module UpdateRepo
     # @return [void]
     def repostat(status)
       # only print if not quiet and not verbose!
-      return if @settings[:quiet] || @settings[:verbose]
+      return if @cmd[:quiet] || @cmd[:verbose]
       @legend.each do |key, value|
         print value[:char].send(value[:color].to_sym) if status[key]
       end

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -66,6 +66,10 @@ module UpdateRepo
       end
     end
 
+    def logfile
+      @logfile.path
+    end
+
     # returns non nil if we have been called originally by one of the Repo
     # update output functions.
     # @param [none]

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -66,6 +66,8 @@ module UpdateRepo
       end
     end
 
+    # Return a string containing the logfile name and full path.
+    # @return [string]
     def logfile
       @logfile.path
     end


### PR DESCRIPTION
Clean up and simplify the way that we can access command line and configuration file parameters internally.

- Add a `#[]` method to the CmdConfig class so that simply passing the class instance to another class initialize method will give access to all the configuration settings using (eg) `cmd[:quiet]`
- We now display the log filename (if enabled) in the header.