### PR TITLE
Add '--log-local' option

### DIFF
--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -121,7 +121,7 @@ EOS
         # opt :import, "Import a previous dump of directories and Git repository URL's,\n(created using --dump) then proceed to clone them locally.", default: false
         opt :log, "Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.", default: false
         opt :timestamp, 'Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.', default: false
-        # opt :log_local, 'Create the logfile in the current directory instead of in the users home directory', default: false, short: 'o'
+        opt :log_local, 'Create the logfile in the current directory instead of in the users home directory', default: false, short: 'g'
         opt :dump_remote, 'Create a dump to screen or log, listing all the git remote URLS found in the specified directories.', default: false, short: 'r'
         opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format.', default: false, short: 'u'
         opt :verbose, 'Display each repository and the git output to screen', default: false, short: 'V'

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -31,12 +31,18 @@ module UpdateRepo
     # @param [none]
     # @return [string] Filename for the logfile.
     def generate_filename
+      # add a timestamp if requested
       if @cmd[:timestamp]
         name = 'updaterepo-' + Time.new.strftime('%y%m%d-%H%M%S') + '.log'
       else
         name = 'updaterepo.log'
       end
-      File.expand_path(File.join('~/', name))
+      # log to local directory instead of home directory if requested
+      if @cmd[:log_local]
+        File.expand_path(File.join('./', name))
+      else
+        File.expand_path(File.join('~/', name))
+      end
     end
 
     # this function will simply pass the given string to 'print', and also

--- a/lib/update_repo/version.rb
+++ b/lib/update_repo/version.rb
@@ -1,4 +1,4 @@
 module UpdateRepo
   # constant, current version of this Gem
-  VERSION = '0.9.4'.freeze
+  VERSION = '0.9.5'.freeze
 end


### PR DESCRIPTION
using the command line parameter `--log-local` will put the log file (if enabled) into the current working directory instead of the users home directory.
Equivalent configuration option would be `log_local: true` in the config file.