### PR TITLE
Produce verbose error messages in the summary by default

### DIFF
--- a/.reek
+++ b/.reek
@@ -15,3 +15,6 @@ DuplicateMethodCall:
 
 NestedIterators:
   max_allowed_nesting: 2
+
+TooManyInstanceVariables:
+  max_instance_variables: 5

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Options:
   -r, --dump-remote          Create a dump to screen or log listing all the git remote URLS found in
                              the specified directories.
   -V, --verbose              Display each repository and the git output to screen
+  -E, --verbose-errors       List all the error output from a failing command in the summary, not just the first line
   -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors).
   -v, --version              Print version and exit
   -h, --help                 Show this message
@@ -122,7 +123,6 @@ Add functionality, not in any specific order :
   * re-import the above dump on a different machine or after reinstall. Modify the '--prune' command to apply to this function also, removing the required number of directory levels before importing.
 - Add option to use alternative git command if required, either globally or on a case-by-case basis (see also comments on 'variants' above). Currently the script just uses a blanket `git pull` command on all repositories.
 - Add option to specify a completely different directory for the log file other than the 2 current options of home dir and local dir
-- Add command line and config file option to be more verbose in the git error summary at the end, listing all the error output not just the first line.
 - Document configuration file format and options. `[IN PROGRESS]`
 
 Internal Changes and refactoring :

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ timestamp: true
 verbose: true
 ```
 
+`verbose_errors:` - List all the error output from a failing command in the summary, not just the first line, defaults to FALSE (optional)
+```yaml
+verbose_errors: true
+```
+
 `quiet:` - no output at all, not even the header and footer, defaults to FALSE (optional)
 ```yaml
 quiet: true

--- a/docs/index.html
+++ b/docs/index.html
@@ -209,6 +209,15 @@
           </div><!-- col -->
 
           <div class="col-lg-12 col-md-12">
+            <p><span class="yaml-tag">verbose_errors:</span> - Enable or disable Verbose error reporting in the summary, defaults to FALSE (optional). If this is set to TRUE, the end-of-job summary will list all the error output lines from any failing Git processes, not just the first line. Equivalent to <span class="cmdline">--verbose-errors</span> and <span class="cmdline">--no-verbose-errors</span> on the command line.</p>
+            <pre>
+              <code class="language-yaml">
+                verbose_errors: true
+              </code>
+            </pre>
+          </div><!-- col -->
+
+          <div class="col-lg-12 col-md-12">
             <p><span class="yaml-tag">quiet:</span> - Enable or disable Quiet mode, defaults to FALSE (optional). If this is specified then there will be nothing printed to the terminal except for fatal errors. Overrules the <span class="cmdline">--verbose</span> mode if also specified. Equivalent to <span class="cmdline">--quiet</span> and <span class="cmdline">--no-quiet</span> on the command line.</p>
             <pre>
               <code class="language-yaml">
@@ -232,6 +241,7 @@
                 timestamp: true
                 color: false
                 verbose: true
+                verbose_errors: true
                 quiet: false
               </code>
             </pre>
@@ -264,7 +274,7 @@
               <p>Color</p>
             </div>
             <div class="cmd-body row-body">
-              <p class="cmd-text">Determines if the output will be displayed in color or not. Default is TRUE. Note that regardless of this setting, when --log is specified or --dump, the color is stripped.</p>
+              <p class="cmd-text">Determines if the output will be displayed in color or not. Default is TRUE. Note that regardless of this setting, when one of the &#39;--dump-*&#39; options is specified output will not be in color. No color codes will be saved to the logfile either.</p>
               <p class="cmd-text">Equivalent to the <span class="yaml-tag">color:</span> YAML configuration file tag.
               </p>
               <ul class="opt-list">
@@ -312,7 +322,7 @@
               <p>Log</p>
             </div>
             <div class="cmd-body row-body">
-              <p class="cmd-text">Copies all script output to a logfile as well as STDOUT. The default logfile name is &#39;updaterepo.log&#39; in the current directory. The previous log will be overwritten, but see the next option.</p>
+              <p class="cmd-text">Copies all script output to a logfile as well as STDOUT. The default logfile name is &#39;updaterepo.log&#39; in the current users home directory. The previous log will be overwritten, but see the next option.</p>
               <p class="cmd-text">Equivalent to the <span class="yaml-tag">log:</span> YAML configuration file tag.
               </p>
               <ul class="opt-list">
@@ -367,6 +377,22 @@
                 <li class="cmd-opt"><span class="desc">Long-Form</span> : <span class="cmdline">--verbose</span></li>
                 <li class="cmd-opt"><span class="desc">Short-Form</span> : <span class="cmdline">-V</span></li>
                 <li class="cmd-opt"><span class="desc">Negative-Form</span> : <span class="cmdline">--no-verbose</span></li>
+                <li class="cmd-opt"><span class="desc">Default</span> : <span class="cmdline">false</span></li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-lg-12 col-md-12">
+            <div class="cmd-header row-header">
+              <p>Verbose Errors</p>
+            </div>
+            <div class="cmd-body row-body">
+              <p class="cmd-text">List all the error output from a failing command in the summary, not just the first line</p>
+              <p class="cmd-text">Equivalent to the <span class="yaml-tag">verbose_errors:</span> YAML configuration file tag.
+              </p>
+              <ul class="opt-list">
+                <li class="cmd-opt"><span class="desc">Long-Form</span> : <span class="cmdline">--verbose-errors</span></li>
+                <li class="cmd-opt"><span class="desc">Short-Form</span> : <span class="cmdline">-E</span></li>
+                <li class="cmd-opt"><span class="desc">Negative-Form</span> : <span class="cmdline">--no-verbose-errors</span></li>
                 <li class="cmd-opt"><span class="desc">Default</span> : <span class="cmdline">false</span></li>
               </ul>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -262,6 +262,7 @@
                   -g, --log-local            Create the logfile in the current directory instead of in the users home directory
                   -r, --dump-remote          Create a dump to screen or log listing all the git remote URLS found in the specified directories.
                   -V, --verbose              Display each repository and the git output to screen
+                  -E, --verbose-errors       List all the error output from a failing command in the summary, not just the first line
                   -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors).
                   -v, --version              Print version and exit
                   -h, --help                 Show this message

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -136,7 +136,7 @@ module UpdateRepo
     #   update_repo('/Repo/linux/stable')
     def update_repo(dirpath)
       # create the git instance and then perform the update
-      git = GitControl.new(dirpath, @log, @metrics)
+      git = GitControl.new(dirpath, @log, @metrics, @cmd)
       git.update
       @metrics[:processed] += 1
       # update the metrics

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -126,6 +126,7 @@ module UpdateRepo
         opt :dump_remote, 'Create a dump to screen or log, listing all the git remote URLS found in the specified directories.', default: false, short: 'r'
         opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format.', default: false, short: 'u'
         opt :verbose, 'Display each repository and the git output to screen', default: false, short: 'V'
+        opt :verbose_errors, 'List all the error output from a failing command in the summary, not just the first line', default: false, short: 'E'
         opt :quiet, 'Run completely silent, with no output to the terminal (except fatal errors).', default: false
       end
     end

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -79,7 +79,7 @@ module UpdateRepo
       # print out any and all errors into a nice list
       @metrics[:failed_list].each do |failed|
         print_log "\n  [", 'x'.red, "] #{failed[:loc]}"
-        print_log "\n    -> ", "\"#{failed[:line].chomp}\"".red
+        print_log "\n    -> ", failed[:line].chomp.red
       end
     end
 
@@ -91,7 +91,7 @@ module UpdateRepo
       @metrics[:failed_list].uniq! { |error| error[:loc] }
     end
 
-    # Print a list of any defined expections that will not be updated.
+    # Print a list of any defined exceptions that will not be updated.
     # @return [void]
     # @param [none]
     def list_exceptions

--- a/lib/update_repo/git_control.rb
+++ b/lib/update_repo/git_control.rb
@@ -16,14 +16,16 @@ module UpdateRepo
     # @param dir [string] The directory location of this local repo.
     # @param logger [instance] pointer to the Logger class
     # @param metrics [instance] pointer to the Metrics class
+    # @param cmd [instance] pointer to the command options class
     # @return [void]
     # @example
     #   git = GitControl.new(repo_url, @logger, @metrics)
-    def initialize(dir, logger, metrics)
+    def initialize(dir, logger, metrics, cmd)
       @status = { updated: false, failed: false, unchanged: false }
       @dir = dir
       @log = logger
       @metrics = metrics
+      @cmd = cmd
     end
 
     # Update the git repo that was specified in the initializer.
@@ -58,7 +60,7 @@ module UpdateRepo
       # see if this error already has some text (metric exists)
       err = @metrics[:failed_list].find { |fail| fail[:loc] == err_loc }
       # if so we append this new line to it otherwise create the metric
-      if err
+      if err && @cmd[:verbose_errors]
         err[:line] = err[:line] + ' ' * 7 + line
       else
         @metrics[:failed_list].push(loc: err_loc, line: line)

--- a/lib/update_repo/git_control.rb
+++ b/lib/update_repo/git_control.rb
@@ -48,18 +48,36 @@ module UpdateRepo
       `git -C #{@dir} config remote.origin.url`.chomp
     end
 
+    # adds a line to the fail matrix (with it's location) if it does not already
+    # exist, otherwise it will add the line to the end of the previous for that
+    # location
+    # @param lin [string] The string containing the Git output line
+    # @return [void]
+    def update_fail_matrix(line)
+      err_loc = "#{@dir} (#{repo_url})"
+      # see if this error already has some text (metric exists)
+      err = @metrics[:failed_list].find { |fail| fail[:loc] == err_loc }
+      # if so we append this new line to it otherwise create the metric
+      if err
+        err[:line] = err[:line] + ' ' * 7 + line
+      else
+        @metrics[:failed_list].push(loc: err_loc, line: line)
+      end
+    end
+
     # print a git output line and update the metrics if an update has occurred
     # @param line [string] The string containing the git output line
     # @return [void]
     # rubocop:disable Metrics/LineLength
     def handle_output(line)
-      if line.chomp =~ /^fatal:|^error:/
-        print_log '   ', line.red
-        @status[:failed] = true
-        err_loc = "#{@dir} (#{repo_url})"
-        @metrics[:failed_list].push(loc: err_loc, line: line)
+      @status[:failed] = true if line.chomp =~ /^fatal:|^error:/
+      # @status[:failed] will persist throughout this entire git call.
+      if @status[:failed]
+        print_log ' ' * 3, line.red
+        # add new or update the fail matrix with another line
+        update_fail_matrix(line)
       else
-        print_log '   ', line.cyan
+        print_log ' ' * 3, line.cyan
         @status[:updated] = true if line =~ /^Updating\s[0-9a-f]{7}\.\.[0-9a-f]{7}/
         @status[:unchanged] = true if line =~ /^Already up-to-date./
       end

--- a/web/index.html
+++ b/web/index.html
@@ -215,6 +215,7 @@
                   -g, --log-local            Create the logfile in the current directory instead of in the users home directory
                   -r, --dump-remote          Create a dump to screen or log listing all the git remote URLS found in the specified directories.
                   -V, --verbose              Display each repository and the git output to screen
+                  -E, --verbose-errors       List all the error output from a failing command in the summary, not just the first line
                   -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors).
                   -v, --version              Print version and exit
                   -h, --help                 Show this message

--- a/web/index.html
+++ b/web/index.html
@@ -162,6 +162,15 @@
           </div><!-- col -->
 
           <div class="col-lg-12 col-md-12">
+            <p><span class="yaml-tag">verbose_errors:</span> - Enable or disable Verbose error reporting in the summary, defaults to FALSE (optional). If this is set to TRUE, the end-of-job summary will list all the error output lines from any failing Git processes, not just the first line. Equivalent to <span class="cmdline">--verbose-errors</span> and <span class="cmdline">--no-verbose-errors</span> on the command line.</p>
+            <pre>
+              <code class="language-yaml">
+                verbose_errors: true
+              </code>
+            </pre>
+          </div><!-- col -->
+
+          <div class="col-lg-12 col-md-12">
             <p><span class="yaml-tag">quiet:</span> - Enable or disable Quiet mode, defaults to FALSE (optional). If this is specified then there will be nothing printed to the terminal except for fatal errors. Overrules the <span class="cmdline">--verbose</span> mode if also specified. Equivalent to <span class="cmdline">--quiet</span> and <span class="cmdline">--no-quiet</span> on the command line.</p>
             <pre>
               <code class="language-yaml">
@@ -185,6 +194,7 @@
                 timestamp: true
                 color: false
                 verbose: true
+                verbose_errors: true
                 quiet: false
               </code>
             </pre>

--- a/web/webdata.json
+++ b/web/webdata.json
@@ -64,6 +64,15 @@
       "default"    : "false"
     },
     {
+      "title"      : "Verbose Errors",
+      "text"       : "List all the error output from a failing command in the summary, not just the first line",
+      "equivalent" : "verbose_errors:",
+      "long-form"  : "--verbose-errors",
+      "short-form" : "-E",
+      "negative"   : "--no-verbose-errors",
+      "default"    : "false"
+    },
+    {
       "title"      : "Quiet",
       "text"       : "No output will be displayed to screen during the running of script, except for any fatal errors.",
       "equivalent" : "quiet:",


### PR DESCRIPTION
Add a flag '--verbose-errors' which will log the full error messages to the end-of-job summary, not just the first line. 
This is currently set as the **non-default** option. I may consider swapping this in the future so that verbose errors are the default, depending on feedback and further usage experience.

Also, if there is an error in a Git operation, the whole output for that operation will now be in Red, not just the first line.
