### PR TITLE
Brief output, no header, footer or summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ verbose: true
 verbose_errors: true
 ```
 
+`brief:` - Do not print the header, footer or summary, defaults to FALSE (optional)
+```yaml
+brief: true
+```
+
 `quiet:` - no output at all, not even the header and footer, defaults to FALSE (optional)
 ```yaml
 quiet: true

--- a/README.md
+++ b/README.md
@@ -97,19 +97,20 @@ Enter `update_repo --help` at the command prompt to get a list of available opti
 Options:
   -c, --color, --no-color    Use colored output (default: true)
   -d, --dump                 Dump a list of Directories and Git URL's to STDOUT in CSV format
-  -p, --prune=<i>            Number of directory levels to remove from the --dump output.
+  -p, --prune=<i>            Number of directory levels to remove from the --dump output
                              Only valid when --dump or -d specified (Default: 0)
   -l, --log                  Create a logfile of all program output to './update_repo.log'.
-                             Any older logs will be overwritten.
+                             Any older logs will be overwritten
   -t, --timestamp            Timestamp the logfile instead of overwriting. Does nothing unless the
-                             --log option is also specified.
+                             --log option is also specified
   -g, --log-local            Create the logfile in the current directory instead of in the users home
-                             directory.
+                             directory
   -r, --dump-remote          Create a dump to screen or log listing all the git remote URLS found in
-                             the specified directories.
+                             the specified directories
   -V, --verbose              Display each repository and the git output to screen
   -E, --verbose-errors       List all the error output from a failing command in the summary, not just the first line
-  -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors).
+  -b, --brief                Do not print the header, footer or summary
+  -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors)
   -v, --version              Print version and exit
   -h, --help                 Show this message
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -217,6 +217,15 @@
           </div><!-- col -->
 
           <div class="col-lg-12 col-md-12">
+            <p><span class="yaml-tag">brief:</span> - Do not print the header, footer or summary, defaults to FALSE (optional). If this is set to TRUE, there will be no extra output except that from each git operation or the non-verbose legend. Equivalent to <span class="cmdline">--brief</span> and <span class="cmdline">--no-brief</span> on the command line.</p>
+            <pre>
+              <code class="language-yaml">
+                brief: true
+              </code>
+            </pre>
+          </div><!-- col -->
+
+          <div class="col-lg-12 col-md-12">
             <p><span class="yaml-tag">quiet:</span> - Enable or disable Quiet mode, defaults to FALSE (optional). If this is specified then there will be nothing printed to the terminal except for fatal errors. Overrules the <span class="cmdline">--verbose</span> mode if also specified. Equivalent to <span class="cmdline">--quiet</span> and <span class="cmdline">--no-quiet</span> on the command line.</p>
             <pre>
               <code class="language-yaml">
@@ -241,6 +250,7 @@
                 color: false
                 verbose: true
                 verbose_errors: true
+                brief: false
                 quiet: false
               </code>
             </pre>
@@ -256,13 +266,14 @@
                   -c, --color, --no-color    Use colored output (default: true)
                   -d, --dump                 Dump a list of Directories and Git URL's to STDOUT in CSV format
                   -p, --prune=&lt;i&gt;            Number of directory levels to remove from the --dump output. Only valid when --dump or -d specified (Default: 0)
-                  -l, --log                  Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.
-                  -t, --timestamp            Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.
+                  -l, --log                  Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten
+                  -t, --timestamp            Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified
                   -g, --log-local            Create the logfile in the current directory instead of in the users home directory
-                  -r, --dump-remote          Create a dump to screen or log listing all the git remote URLS found in the specified directories.
+                  -r, --dump-remote          Create a dump to screen or log listing all the git remote URLS found in the specified directories
                   -V, --verbose              Display each repository and the git output to screen
                   -E, --verbose-errors       List all the error output from a failing command in the summary, not just the first line
-                  -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors).
+                  -b, --brief                Do not print the header, footer or summary
+                  -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors)
                   -v, --version              Print version and exit
                   -h, --help                 Show this message
               </code>
@@ -393,6 +404,22 @@
                 <li class="cmd-opt"><span class="desc">Long-Form</span> : <span class="cmdline">--verbose-errors</span></li>
                 <li class="cmd-opt"><span class="desc">Short-Form</span> : <span class="cmdline">-E</span></li>
                 <li class="cmd-opt"><span class="desc">Negative-Form</span> : <span class="cmdline">--no-verbose-errors</span></li>
+                <li class="cmd-opt"><span class="desc">Default</span> : <span class="cmdline">false</span></li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-lg-12 col-md-12">
+            <div class="cmd-header row-header">
+              <p>Brief Output</p>
+            </div>
+            <div class="cmd-body row-body">
+              <p class="cmd-text">Do not print the Header, Footer or Summary.</p>
+              <p class="cmd-text">Equivalent to the <span class="yaml-tag">brief:</span> YAML configuration file tag.
+              </p>
+              <ul class="opt-list">
+                <li class="cmd-opt"><span class="desc">Long-Form</span> : <span class="cmdline">--brief</span></li>
+                <li class="cmd-opt"><span class="desc">Short-Form</span> : <span class="cmdline">-b</span></li>
+                <li class="cmd-opt"><span class="desc">Negative-Form</span> : <span class="cmdline">--no-brief</span></li>
                 <li class="cmd-opt"><span class="desc">Default</span> : <span class="cmdline">false</span></li>
               </ul>
             </div>

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -127,6 +127,7 @@ module UpdateRepo
         opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format.', default: false, short: 'u'
         opt :verbose, 'Display each repository and the git output to screen', default: false, short: 'V'
         opt :verbose_errors, 'List all the error output from a failing command in the summary, not just the first line', default: false, short: 'E'
+        opt :brief, 'Do not print the header and footer / summary.', default: false, short: 'b'
         opt :quiet, 'Run completely silent, with no output to the terminal (except fatal errors).', default: false
       end
     end

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -118,17 +118,17 @@ module UpdateRepo
         EOS
         opt :color, 'Use colored output', default: true
         opt :dump, 'Dump a list of Directories and Git URL\'s to STDOUT in CSV format', default: false
-        opt :prune, "Number of directory levels to remove from the --dump output.\nOnly valid when --dump or -d specified.", default: 0
+        opt :prune, "Number of directory levels to remove from the --dump output.\nOnly valid when --dump or -d specified", default: 0
         # opt :import, "Import a previous dump of directories and Git repository URL's,\n(created using --dump) then proceed to clone them locally.", default: false
-        opt :log, "Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.", default: false
-        opt :timestamp, 'Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.', default: false
+        opt :log, "Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten", default: false
+        opt :timestamp, 'Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified', default: false
         opt :log_local, 'Create the logfile in the current directory instead of in the users home directory', default: false, short: 'g'
-        opt :dump_remote, 'Create a dump to screen or log, listing all the git remote URLS found in the specified directories.', default: false, short: 'r'
-        opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format.', default: false, short: 'u'
+        opt :dump_remote, 'Create a dump to screen or log, listing all the git remote URLS found in the specified directories', default: false, short: 'r'
+        opt :dump_tree, 'Create a dump to screen or log, listing all subdirectories found below the specified locations in tree format', default: false, short: 'u'
         opt :verbose, 'Display each repository and the git output to screen', default: false, short: 'V'
         opt :verbose_errors, 'List all the error output from a failing command in the summary, not just the first line', default: false, short: 'E'
-        opt :brief, 'Do not print the header and footer / summary.', default: false, short: 'b'
-        opt :quiet, 'Run completely silent, with no output to the terminal (except fatal errors).', default: false
+        opt :brief, 'Do not print the header, footer or summary', default: false, short: 'b'
+        opt :quiet, 'Run completely silent, with no output to the terminal (except fatal errors)', default: false
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -28,18 +28,20 @@ module UpdateRepo
     # @return [void]
     # @param [none]
     def show_header
-      # print an informative header before starting
-      print_log "\nGit Repo update utility (v", VERSION, ')',
-                " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
-      print_log "Using Configuration from '#{@cmd.getconfig.config_path}'\n"
-      # show the logfile location, but only if it is enabled
-      show_logfile
-      # list out the locations that will be searched
-      list_locations
-      # list any exceptions that we have from the config file
-      list_exceptions
-      # save the start time for later display in the footer...
-      @metrics[:start_time] = Time.now
+      unless @cmd[:brief]
+        # print an informative header before starting
+        print_log "\nGit Repo update utility (v", VERSION, ')',
+                  " \u00A9 Grant Ramsay <seapagan@gmail.com>\n"
+        print_log "Using Configuration from '#{@cmd.getconfig.config_path}'\n"
+        # show the logfile location, but only if it is enabled
+        show_logfile
+        # list out the locations that will be searched
+        list_locations
+        # list any exceptions that we have from the config file
+        list_exceptions
+        # save the start time for later display in the footer...
+        @metrics[:start_time] = Time.now
+      end
       print_log "\n" # blank line before processing starts
     end
 
@@ -47,9 +49,11 @@ module UpdateRepo
     # @return [void]
     # @param [none]
     def show_footer
-      duration = Time.now - @metrics[:start_time]
-      print_log "\nUpdates completed in ", show_time(duration).cyan
-      print_metrics
+      unless @cmd[:brief]
+        duration = Time.now - @metrics[:start_time]
+        print_log "\n\nUpdates completed in ", show_time(duration).cyan
+        print_metrics
+      end
       print_log " \n\n"
       # close the log file now as we are done, just to be sure ...
       @log.close

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -87,7 +87,7 @@ module UpdateRepo
       # prefix if exists
       calling_fn = caller_locations[2].label.gsub(/block in /, '')
       # array with the functions we want to skip
-      repo_output = %w[do_update handle_output skip_repo update]
+      repo_output = %w[do_update print_line handle_output skip_repo update]
       # return TRUE if DOES match, FALSE otherwise.
       repo_output.include?(calling_fn) ? true : false
     end

--- a/web/index.html
+++ b/web/index.html
@@ -170,6 +170,15 @@
           </div><!-- col -->
 
           <div class="col-lg-12 col-md-12">
+            <p><span class="yaml-tag">brief:</span> - Do not print the header, footer or summary, defaults to FALSE (optional). If this is set to TRUE, there will be no extra output except that from each git operation or the non-verbose legend. Equivalent to <span class="cmdline">--brief</span> and <span class="cmdline">--no-brief</span> on the command line.</p>
+            <pre>
+              <code class="language-yaml">
+                brief: true
+              </code>
+            </pre>
+          </div><!-- col -->
+
+          <div class="col-lg-12 col-md-12">
             <p><span class="yaml-tag">quiet:</span> - Enable or disable Quiet mode, defaults to FALSE (optional). If this is specified then there will be nothing printed to the terminal except for fatal errors. Overrules the <span class="cmdline">--verbose</span> mode if also specified. Equivalent to <span class="cmdline">--quiet</span> and <span class="cmdline">--no-quiet</span> on the command line.</p>
             <pre>
               <code class="language-yaml">
@@ -194,6 +203,7 @@
                 color: false
                 verbose: true
                 verbose_errors: true
+                brief: false
                 quiet: false
               </code>
             </pre>
@@ -209,13 +219,14 @@
                   -c, --color, --no-color    Use colored output (default: true)
                   -d, --dump                 Dump a list of Directories and Git URL's to STDOUT in CSV format
                   -p, --prune=&lt;i&gt;            Number of directory levels to remove from the --dump output. Only valid when --dump or -d specified (Default: 0)
-                  -l, --log                  Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten.
-                  -t, --timestamp            Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified.
+                  -l, --log                  Create a logfile of all program output to './update_repo.log'. Any older logs will be overwritten
+                  -t, --timestamp            Timestamp the logfile instead of overwriting. Does nothing unless the --log option is also specified
                   -g, --log-local            Create the logfile in the current directory instead of in the users home directory
-                  -r, --dump-remote          Create a dump to screen or log listing all the git remote URLS found in the specified directories.
+                  -r, --dump-remote          Create a dump to screen or log listing all the git remote URLS found in the specified directories
                   -V, --verbose              Display each repository and the git output to screen
                   -E, --verbose-errors       List all the error output from a failing command in the summary, not just the first line
-                  -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors).
+                  -b, --brief                Do not print the header, footer or summary
+                  -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors)
                   -v, --version              Print version and exit
                   -h, --help                 Show this message
               </code>

--- a/web/webdata.json
+++ b/web/webdata.json
@@ -73,6 +73,15 @@
       "default"    : "false"
     },
     {
+      "title"      : "Brief Output",
+      "text"       : "Do not print the Header, Footer or Summary.",
+      "equivalent" : "brief:",
+      "long-form"  : "--brief",
+      "short-form" : "-b",
+      "negative"   : "--no-brief",
+      "default"    : "false"
+    },
+    {
       "title"      : "Quiet",
       "text"       : "No output will be displayed to screen during the running of script, except for any fatal errors.",
       "equivalent" : "quiet:",


### PR DESCRIPTION
This will squelch printing the header, footer and summary when the `--brief` or `-b` flags are set, or `brief: true` is set in the configuration file. The default is false.
As always, this behaviour can be negated using `--no-brief` on the command line.