### PR TITLE
Save and display previous errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: ruby
 
 rvm:
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 
 before_install:
   - gem update --system

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in update_repo.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'inch/rake'

--- a/exe/update_repo
+++ b/exe/update_repo
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'update_repo'
 
 # Catch ctrl-c and abort gracefully without Ruby back trace...

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -51,7 +51,6 @@ module UpdateRepo
         # print out an informative footer unless dump / import ...
         @cons.show_footer unless dumping?
       else
-        puts 'Showing ' + 'ERRORS'.red.underline + ' from last full run :'
         @cons.show_last_errors
       end
     end

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -42,11 +42,17 @@ module UpdateRepo
       checkgit
       # print out our header unless we are dumping / importing ...
       @cons.show_header unless dumping?
-      config['location'].each do |loc|
-        @cmd[:dump_tree] ? dump_tree(File.join(loc)) : recurse_dir(loc)
+      if !@cmd[:show_errors]
+        config['location'].each do |loc|
+          @cmd[:dump_tree] ? dump_tree(File.join(loc)) : recurse_dir(loc)
+        end
+        # print out an informative footer unless dump / import ...
+        @cons.show_footer unless dumping?
+      else
+        puts 'Showing ' + 'ERRORS'.red.underline + ' from last full run :'
+        @cons.show_last_errors
+        puts
       end
-      # print out an informative footer unless dump / import ...
-      @cons.show_footer unless dumping?
     end
 
     private

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'update_repo/version'
 require 'update_repo/helpers'
 require 'update_repo/cmd_config'

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -51,7 +51,6 @@ module UpdateRepo
       else
         puts 'Showing ' + 'ERRORS'.red.underline + ' from last full run :'
         @cons.show_last_errors
-        puts
       end
     end
 

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'update_repo/version'
 require 'update_repo/helpers'
 require 'confoog'
@@ -13,9 +15,9 @@ module UpdateRepo
     include Helpers
 
     # This constant holds the path to the config file, default to home dir.
-    CONFIG_PATH = '~/'.freeze
+    CONFIG_PATH = '~/'
     # This constant holds the filename of the config file.
-    CONFIG_FILE = '.updaterepo'.freeze
+    CONFIG_FILE = '.updaterepo'
 
     def initialize
       # read the options from Trollop and store in temp variable.

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -100,6 +100,7 @@ module UpdateRepo
     # @return [void]
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/LineLength
+    # rubocop:disable Metrics/AbcSize
     def set_options
       Optimist.options do
         version "update_repo version #{VERSION} (C)2019 G. Ramsay\n"
@@ -130,9 +131,12 @@ module UpdateRepo
         opt :verbose_errors, 'List all the error output from a failing command in the summary, not just the first line', default: false, short: 'E'
         opt :brief, 'Do not print the header, footer or summary', default: false, short: 'b'
         opt :quiet, 'Run completely silent, with no output to the terminal (except fatal errors)', default: false
+        opt :save_errors, 'Save any Git error messages from the last run for future display', default: false, short: 's'
+        opt :show_errors, 'Show any Git error messages from the last run of the script', default: false, short: 'S'
       end
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable  Metrics/LineLength
+    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -70,6 +70,7 @@ module UpdateRepo
       end
       print_log ' |'
       list_failures unless @metrics[:failed_list].empty?
+      @metrics.save_errors(@cmd.getconfig) if @cmd[:save_errors]
     end
 
     # List any repositories that failed their update, and the error.
@@ -86,7 +87,7 @@ module UpdateRepo
         print_log "\n  [", 'x'.red, "] #{failed[:loc]}"
         print_log "\n    -> ", failed[:line].chomp.red
       end
-      @metrics.save_errors(@cmd.getconfig) if @cmd[:save_errors]
+      print_log " \n\n"
     end
 
     # removes any duplications in the list of failed repos.

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -78,13 +78,15 @@ module UpdateRepo
     def list_failures
       # ensure we don't have duplicate errors from the same repo
       remove_dups
-      print_log "\n\n!! Note : The following #{@metrics[:failed_list].count}",
+      puts "\n" unless @cmd[:show_errors]
+      print_log "\n!! Note : The following #{@metrics[:failed_list].count}",
                 ' repositories ', 'FAILED'.red.underline, ' during this run :'
       # print out any and all errors into a nice list
       @metrics[:failed_list].each do |failed|
         print_log "\n  [", 'x'.red, "] #{failed[:loc]}"
         print_log "\n    -> ", failed[:line].chomp.red
       end
+      @metrics.save_errors(@cmd.getconfig) if @cmd[:save_errors]
     end
 
     # removes any duplications in the list of failed repos.
@@ -122,6 +124,13 @@ module UpdateRepo
       return unless @cmd[:log]
 
       print_log "\nLogging to file:".underline, " #{@log.logfile}\n".cyan
+    end
+
+    # just print out errors from the last run, if any
+    # @return [void]
+    def show_last_errors
+      @metrics.load_errors(@cmd.getconfig)
+      list_failures unless @metrics[:failed_list].empty?
     end
   end
 end

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -133,7 +133,12 @@ module UpdateRepo
     # @return [void]
     def show_last_errors
       @metrics.load_errors(@cmd.getconfig)
-      list_failures unless @metrics[:failed_list].empty?
+      if !@metrics[:failed_list].empty?
+        puts 'Showing ' + 'ERRORS'.red.underline + ' from last full run :'
+        list_failures
+      else
+        puts 'There are' + ' No Errors'.green + " from last full run.\n\n"
+      end
     end
   end
 end

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'update_repo/version'
 require 'update_repo/helpers'
 

--- a/lib/update_repo/git_control.rb
+++ b/lib/update_repo/git_control.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'update_repo/version'
 require 'update_repo/helpers'
 require 'open3'

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Module 'Helpers' containing assorted helper functions required elsewhere
 module Helpers
   # will remove the FIRST 'how_many' root levels from a directory path 'dir'..

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -101,7 +101,7 @@ module UpdateRepo
     # @param [none]
     # @return [void]
     def close
-      @logfile.close if @logfile
+      @logfile&.close # if @logfile
     end
   end
 end

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'update_repo/version'
 require 'update_repo/helpers'
 

--- a/lib/update_repo/metrics.rb
+++ b/lib/update_repo/metrics.rb
@@ -36,13 +36,17 @@ module UpdateRepo
 
     # This will save any (git) errors encountered to a file,
     # so they can be reprinted again at a later date.
+    # If no errors, then delete any previously existing error file.
     def save_errors(config)
-      return if @metrics[:failed_list].empty?
-
-      # get the location of the config file, we'll use the same dir
-      # and base name
       path = config.config_path + '.errors'
-      File.open(path, 'w') { |file| file.write @metrics[:failed_list].to_yaml }
+      if @metrics[:failed_list].empty?
+        # delete any existing  file
+        File.delete(path) if File.exist(path)
+      else
+        # get the location of the config file, we'll use the same dir
+        # and base name
+        File.open(path, 'w') { |file| file.write @metrics[:failed_list].to_yaml }
+      end
     end
 
     # loads an error file (if exists) into the @metrics[:failed_list].

--- a/lib/update_repo/metrics.rb
+++ b/lib/update_repo/metrics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'update_repo/version'
 require 'update_repo/helpers'
 require 'yaml'

--- a/lib/update_repo/metrics.rb
+++ b/lib/update_repo/metrics.rb
@@ -40,7 +40,6 @@ module UpdateRepo
       # get the location of the config file, we'll use the same dir
       # and base name
       path = config.config_path + '.errors'
-      puts "Saving errors to #{path}"
       File.open(path, 'w') { |file| file.write @metrics[:failed_list].to_yaml }
     end
 

--- a/lib/update_repo/metrics.rb
+++ b/lib/update_repo/metrics.rb
@@ -37,19 +37,24 @@ module UpdateRepo
     # This will save any (git) errors encountered to a file,
     # so they can be reprinted again at a later date.
     # If no errors, then delete any previously existing error file.
+    # @param config [instance] of Config class
+    # @return [void]
     def save_errors(config)
+      # get the location of the config file, we'll use the same dir
+      # and base name
       path = config.config_path + '.errors'
       if @metrics[:failed_list].empty?
-        # delete any existing  file
-        File.delete(path) if File.exist(path)
+        # delete any existing  file if we have no errors
+        File.delete(path) if File.exist?(path)
       else
-        # get the location of the config file, we'll use the same dir
-        # and base name
+        # otherwise save  the errors to file
         File.open(path, 'w') { |file| file.write @metrics[:failed_list].to_yaml }
       end
     end
 
     # loads an error file (if exists) into the @metrics[:failed_list].
+    # @param config [instance] of Config class
+    # @return [void]
     def load_errors(config)
       path = config.config_path + '.errors'
       @metrics[:failed_list] = YAML.load_file(path) if File.exist?(path)

--- a/lib/update_repo/metrics.rb
+++ b/lib/update_repo/metrics.rb
@@ -1,5 +1,6 @@
 require 'update_repo/version'
 require 'update_repo/helpers'
+require 'yaml'
 
 module UpdateRepo
   # Class : Metrics.
@@ -29,6 +30,24 @@ module UpdateRepo
     # @return [value] Return the value set.
     def []=(key, value)
       @metrics[key] = value
+    end
+
+    # This will save any (git) errors encountered to a file,
+    # so they can be reprinted again at a later date.
+    def save_errors(config)
+      return if @metrics[:failed_list].empty?
+
+      # get the location of the config file, we'll use the same dir
+      # and base name
+      path = config.config_path + '.errors'
+      puts "Saving errors to #{path}"
+      File.open(path, 'w') { |file| file.write @metrics[:failed_list].to_yaml }
+    end
+
+    # loads an error file (if exists) into the @metrics[:failed_list].
+    def load_errors(config)
+      path = config.config_path + '.errors'
+      @metrics[:failed_list] = YAML.load_file(path) if File.exist?(path)
     end
   end
 end

--- a/lib/update_repo/version.rb
+++ b/lib/update_repo/version.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 module UpdateRepo
   # constant, current version of this Gem
-  VERSION = '0.9.10'.freeze
+  VERSION = '0.9.10'
 end

--- a/spec/cmd_config_spec.rb
+++ b/spec/cmd_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe UpdateRepo::CmdConfig do

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe UpdateRepo::Logger do

--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe UpdateRepo::Metrics, '- Class to store & return run metrics' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'should_not/rspec'
 require 'simplecov'

--- a/spec/update_repo_spec.rb
+++ b/spec/update_repo_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe UpdateRepo do

--- a/web/index.html
+++ b/web/index.html
@@ -188,6 +188,15 @@
           </div><!-- col -->
 
           <div class="col-lg-12 col-md-12">
+            <p><span class="yaml-tag">save_errors:</span> - Enable or disable the option to save any Git errors from a previous run of the script, defaults to FALSE (optional). If this is specified then there will be nothing printed to the terminal except for fatal errors. Equivalent to <span class="cmdline">--save-errors</span> on the command line. Once saved, errors can be displayed using the <span class="cmdline">--show-errors</span> command line option.</p>
+            <pre>
+              <code class="language-yaml">
+                save-errors: true
+              </code>
+            </pre>
+          </div><!-- col -->
+
+          <div class="col-lg-12 col-md-12">
             <p>Putting these together, below is an example <span class="filename">.updaterepo</span> file :</p>
             <pre>
               <code class="language-yaml">
@@ -227,6 +236,8 @@
                   -E, --verbose-errors       List all the error output from a failing command in the summary, not just the first line
                   -b, --brief                Do not print the header, footer or summary
                   -q, --quiet                Run completely silent, with no output to the terminal (except fatal errors)
+                  -s, --save-errors          Save any Git error messages from the last run for future display
+                  -S, --show-errors          Show any Git error messages from the last run of the script
                   -v, --version              Print version and exit
                   -h, --help                 Show this message
               </code>

--- a/web/webdata.json
+++ b/web/webdata.json
@@ -100,6 +100,24 @@
       "default"    : "false"
     },
     {
+      "title"      : "Save Errors",
+      "text"       : "Save any Git error messages from the last run for future display. These can be displayed using the Show Errors command below, which will display previous errors then exit without running another pass.",
+      "equivalent" : "save_errors",
+      "long-form"  : "--save-errors",
+      "short-form" : "-s",
+      "negative"   : "",
+      "default"    : "false"
+    },
+    {
+      "title"      : "Show Errors",
+      "text"       : "Prints any errors detected in the previous run then exits. This needs the 'Save Errors' option above to be enabled.",
+      "equivalent" : "",
+      "long-form"  : "--show-errors",
+      "short-form" : "-S",
+      "negative"   : "",
+      "default"    : "false"
+    },
+    {
       "title"      : "Version",
       "text"       : "Displays the current version number then terminates. All other options will be ignored.",
       "equivalent" : "",


### PR DESCRIPTION
save any errors from a run to a file with option -s so they can be displayed next time using option .-S