### PR TITLE
Version updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 *.sublime*
 node_modules
 .vagrant
+.vscode

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,15 @@
 require: rubocop-performance
 
 AllCops:
+  NewCops: enable
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: true
   Exclude:
-    - 'web/node_modules/**/*'
-    - 'Vagrantfile'
-    - 'update_repo.gemspec'
-    - 'bin/**/*'
+    - "web/node_modules/**/*"
+    - "Vagrantfile"
+    - "update_repo.gemspec"
+    - "bin/**/*"
 
 Style/SymbolArray:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
 
 rvm:
-  - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.2
 
 before_install:
   - gem update --system
-  - gem install bundler -v 1.17.1
+  - gem install bundler -v 2.2.2

--- a/Rakefile
+++ b/Rakefile
@@ -6,36 +6,23 @@ require 'inch/rake'
 
 RSpec::Core::RakeTask.new(:spec)
 
-# rubocop is not compatible with Ruby < 2.0
-if RUBY_VERSION >= '2.0'
-  require 'rubocop/rake_task'
-  RuboCop::RakeTask.new do |task|
-    # task.options << 'lib' << 'exe'
-    task.requires << 'rubocop-performance'
-    task.fail_on_error = false
-  end
-else
-  task :rubocop do
-    # Empty task
-  end
+# rubocop
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new do |task|
+  task.requires << 'rubocop-performance'
+  task.fail_on_error = false
 end
 
 Inch::Rake::Suggest.new do |suggest|
   suggest.args << '--pedantic'
 end
 
-# reek is not compatible with Ruby < 2.1
-if RUBY_VERSION >= '2.1'
-  require 'reek/rake/task'
-  Reek::Rake::Task.new do |t|
-    t.fail_on_error = false
-    t.verbose       = true
-    t.reek_opts     = '-U'
-  end
-else
-  task :reek do
-    # Empty task
-  end
+# reek
+require 'reek/rake/task'
+Reek::Rake::Task.new do |t|
+  t.fail_on_error = false
+  t.verbose       = true
+  t.reek_opts     = '-U'
 end
 
 task default: [:rubocop, :reek, :spec, :inch, :build]

--- a/lib/update_repo.rb
+++ b/lib/update_repo.rb
@@ -46,14 +46,14 @@ module UpdateRepo
       checkgit
       # print out our header unless we are dumping / importing ...
       @cons.show_header unless dumping?
-      if !@cmd[:show_errors]
+      if @cmd[:show_errors]
+        @cons.show_last_errors
+      else
         config['location'].each do |loc|
           @cmd[:dump_tree] ? dump_tree(File.join(loc)) : recurse_dir(loc)
         end
         # print out an informative footer unless dump / import ...
         @cons.show_footer unless dumping?
-      else
-        @cons.show_last_errors
       end
     end
 
@@ -88,7 +88,6 @@ module UpdateRepo
     # a Git repository then update it (or as directed by command line)
     # @param dirname [string] Contains the directory to search for Git repos.]
     # @return [void]
-    # rubocop:disable LineLength
     def recurse_dir(dirname)
       walk_tree(dirname).each do |repo|
         if dumping?
@@ -98,7 +97,6 @@ module UpdateRepo
         end
       end
     end
-    # rubocop:enable LineLength
 
     # walk the specified tree, return an array of hashes holding valid repos
     # @param dirname [string] Directory to use as the base of the search

--- a/lib/update_repo/cmd_config.rb
+++ b/lib/update_repo/cmd_config.rb
@@ -57,7 +57,7 @@ module UpdateRepo
     # @return [various] Returns the true value of the comamnd symbol
     # ignore the :reek:NilCheck for this function
     def true_cmd(command)
-      cmd_given = @conf['cmd'][(command.to_s + '_given').to_sym]
+      cmd_given = @conf['cmd']["#{command}_given".to_sym]
       cmd_line = @conf['cmd'][command.to_sym]
 
       if cmd_given
@@ -72,7 +72,6 @@ module UpdateRepo
       end
     end
 
-    # rubocop:disable Layout/LineLength
     # make sure the parameter combinations are valid, terminating otherwise.
     # @param [none]
     # @return [void]
@@ -82,7 +81,6 @@ module UpdateRepo
       Optimist.die 'You cannot use --dump AND --import'.red if true_cmd(:import)
       Optimist.die 'You cannot use --dump AND --dump-remote'.red if true_cmd(:dump_remote)
     end
-    # rubocop:enable  Layout/LineLength
 
     private
 

--- a/lib/update_repo/console_output.rb
+++ b/lib/update_repo/console_output.rb
@@ -133,11 +133,11 @@ module UpdateRepo
     # @return [void]
     def show_last_errors
       @metrics.load_errors(@cmd.getconfig)
-      if !@metrics[:failed_list].empty?
-        puts 'Showing ' + 'ERRORS'.red.underline + ' from last full run :'
-        list_failures
+      if @metrics[:failed_list].empty?
+        puts "There are#{' No Errors'.green} from last full run.\n\n"
       else
-        puts 'There are' + ' No Errors'.green + " from last full run.\n\n"
+        puts "Showing #{'ERRORS'.red.underline} from last full run :"
+        list_failures
       end
     end
   end

--- a/lib/update_repo/git_control.rb
+++ b/lib/update_repo/git_control.rb
@@ -79,7 +79,7 @@ module UpdateRepo
                          unchanged: '^Already up-to-date.' }
 
       detect_strings.each do |status, regex|
-        @status[status] = true if line.chomp =~ /#{regex}/
+        @status[status] = true if /#{regex}/.match?(line.chomp)
       end
 
       print_line(line, @status)

--- a/lib/update_repo/helpers.rb
+++ b/lib/update_repo/helpers.rb
@@ -23,7 +23,7 @@ module Helpers
   private
 
   def gitdir?(dirpath)
-    gitpath = dirpath + '/.git'
+    gitpath = "#{dirpath}/.git"
     File.exist?(gitpath) && File.directory?(gitpath)
   end
 

--- a/lib/update_repo/logger.rb
+++ b/lib/update_repo/logger.rb
@@ -36,7 +36,7 @@ module UpdateRepo
     def generate_filename
       # add a timestamp if requested
       name = if @cmd[:timestamp]
-               'updaterepo-' + Time.new.strftime('%y%m%d-%H%M%S') + '.log'
+               "updaterepo-#{Time.new.strftime('%y%m%d-%H%M%S')}.log"
              else
                'updaterepo.log'
              end
@@ -54,14 +54,14 @@ module UpdateRepo
     # @return [void]
     def output(*string)
       # nothing to screen if we want to be --quiet
-      unless @cmd[:quiet]
+      if !@cmd[:quiet] && (@cmd[:verbose] || !repo_text?)
         # log header and footer to screen regardless
-        print(*string) if @cmd[:verbose] || !repo_text?
+        print(*string)
       end
       # log to file if that has been enabled
       return unless @cmd[:log]
 
-      @logfile.write(string.join('').gsub(/\e\[(\d+)(;\d+)*m/, ''))
+      @logfile.write(string.join.gsub(/\e\[(\d+)(;\d+)*m/, ''))
     end
 
     # function repostat - outputs a coloured char depending on the status hash,

--- a/lib/update_repo/metrics.rb
+++ b/lib/update_repo/metrics.rb
@@ -42,7 +42,7 @@ module UpdateRepo
     def save_errors(config)
       # get the location of the config file, we'll use the same dir
       # and base name
-      path = config.config_path + '.errors'
+      path = "#{config.config_path}.errors"
       if @metrics[:failed_list].empty?
         # delete any existing  file if we have no errors
         File.delete(path) if File.exist?(path)
@@ -56,7 +56,7 @@ module UpdateRepo
     # @param config [instance] of Config class
     # @return [void]
     def load_errors(config)
-      path = config.config_path + '.errors'
+      path = "#{config.config_path}.errors"
       @metrics[:failed_list] = YAML.load_file(path) if File.exist?(path)
     end
   end

--- a/lib/update_repo/version.rb
+++ b/lib/update_repo/version.rb
@@ -2,5 +2,5 @@
 
 module UpdateRepo
   # constant, current version of this Gem
-  VERSION = '0.11.2'
+  VERSION = '0.11.3'
 end

--- a/update_repo.gemspec
+++ b/update_repo.gemspec
@@ -23,31 +23,21 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake', '~> 12.3'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'fakefs'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'inch'
-  spec.add_development_dependency 'simplecov', '~> 0.12'
+  spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pullreview-coverage'
   spec.add_development_dependency 'should_not'
   spec.add_development_dependency 'wwtd'
+  spec.add_development_dependency 'reek'
+  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop-performance'
 
-  # The below dependencies require at least Ruby 2 for the latest versions.
-  # Below this we fix to the last working versions to keep Ruby 1.9.3 compat or
-  # we ignore completely - Reek and Rubocop working in the latest versions is
-  # enough since the code base is common.
-  spec.add_development_dependency 'reek' if RUBY_VERSION >= '2.1'
-  spec.add_development_dependency 'rubocop' if RUBY_VERSION >= '2.0'
-  spec.add_development_dependency 'rubocop-performance' if RUBY_VERSION >= '2.0'
-
-  if RUBY_VERSION < '2.0'
-    spec.add_development_dependency 'json', '= 1.8.3'
-    spec.add_development_dependency 'tins', '= 1.6.0'
-    spec.add_dependency 'term-ansicolor', '= 1.3.2'
-  end
-
+  # prooduction dependencies
   spec.add_dependency 'colorize'
   spec.add_dependency 'confoog'
   spec.add_dependency 'optimist'

--- a/update_repo.gemspec
+++ b/update_repo.gemspec
@@ -9,7 +9,7 @@ require 'update_repo/version'
 Gem::Specification.new do |spec|
   spec.name          = 'update_repo'
   spec.version       = UpdateRepo::VERSION
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.4.0'
   spec.authors       = ['Grant Ramsay']
   spec.email         = ['seapagan@gmail.com']
 

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.12.0",
     "ansi-colors": "^4.1.1",
-    "bootstrap": "^4.4.1",
+    "bootstrap": "^4.5.3",
     "browser-sync": "^2.26.7",
     "fancy-log": "^1.3.3",
     "gulp": "^4.0.2",
@@ -43,10 +43,10 @@
     "gulp-noop": "^1.0.0",
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^4.0.2",
-    "jquery": "^3.4.1",
+    "jquery": ">=3.5.0",
     "merge-stream": "^2.0.0",
-    "mustache": "^3.2.0",
+    "mustache": "^4.1.0",
     "popper.js": "^1.16.0",
-    "prismjs": "^1.17.1"
+    "prismjs": "^1.22.0"
   }
 }


### PR DESCRIPTION
General behind-the-scenes updates 
* Now only support Ruby 2.4+
* Add new Rubocop Cops and fix the resulting failures
* Update a couple of Node dependencies in the web code. This currently fails - its time to replace Gulp with Webpack

Otherwise no new functionality or changes.